### PR TITLE
feat(logging): add centralized colored logger + tests #36

### DIFF
--- a/GameOn-Frontend/__tests__/logger.test.ts
+++ b/GameOn-Frontend/__tests__/logger.test.ts
@@ -1,0 +1,66 @@
+
+jest.mock('react-native-logs', () => {
+  const instance = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const createLogger = jest.fn(() => instance);
+
+  return {
+    consoleTransport: jest.fn(),
+    logger: { createLogger },
+    __mock__: { instance, createLogger },
+  };
+});
+
+describe('logger.ts', () => {
+  let rnLogs: any;
+
+  beforeEach(() => {
+    (globalThis as any).__DEV__ = false;
+
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    // IMPORTANT: re-require the mock AFTER resetModules so we get a fresh reference
+    rnLogs = require('react-native-logs');
+
+    rnLogs.__mock__.instance.debug.mockClear();
+    rnLogs.__mock__.instance.info.mockClear();
+    rnLogs.__mock__.instance.warn.mockClear();
+    rnLogs.__mock__.instance.error.mockClear();
+    rnLogs.__mock__.createLogger.mockClear();
+    delete process.env.EXPO_PUBLIC_LOG_LEVEL;
+  });
+
+  test('uses severity from EXPO_PUBLIC_LOG_LEVEL', () => {
+    process.env.EXPO_PUBLIC_LOG_LEVEL = 'warn';
+
+    // Import after env var set so module init picks it up
+    jest.isolateModules(() => {
+      require('@/utils/logger'); 
+    });
+
+    expect(rnLogs.__mock__.createLogger).toHaveBeenCalledTimes(1);
+    const arg = rnLogs.__mock__.createLogger.mock.calls[0][0];
+    expect(arg).toMatchObject({ severity: 'warn' });
+  });
+
+  test('exports a singleton and forwards to underlying logger', () => {
+    jest.isolateModules(() => {
+      const { log } = require('@/utils/logger');
+      log.info('hello', { a: 1 });
+      log.warn('careful');
+      log.error('boom');
+      log.debug('details');
+    });
+
+    expect(rnLogs.__mock__.instance.info).toHaveBeenCalledWith('hello', { a: 1 });
+    expect(rnLogs.__mock__.instance.warn).toHaveBeenCalledWith('careful');
+    expect(rnLogs.__mock__.instance.error).toHaveBeenCalledWith('boom');
+    expect(rnLogs.__mock__.instance.debug).toHaveBeenCalledWith('details');
+  });
+
+});

--- a/GameOn-Frontend/package-lock.json
+++ b/GameOn-Frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.4",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-logs": "^5.5.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -13452,6 +13453,11 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-logs": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-logs/-/react-native-logs-5.5.0.tgz",
+      "integrity": "sha512-H3Jc1pNTzNhYb9yHuk1drHdyGHwRvt4IERSz3EUul8vVTey6999fzGRFLK6ugrxYnmw7P+5fo/mRzDXeByhA8g=="
     },
     "node_modules/react-native-reanimated": {
       "version": "4.1.2",

--- a/GameOn-Frontend/package.json
+++ b/GameOn-Frontend/package.json
@@ -35,6 +35,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-logs": "^5.5.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/GameOn-Frontend/utils/logger.ts
+++ b/GameOn-Frontend/utils/logger.ts
@@ -1,0 +1,29 @@
+import { logger, consoleTransport } from 'react-native-logs';
+
+const severity =
+  (process.env.EXPO_PUBLIC_LOG_LEVEL as 'debug' | 'info' | 'warn' | 'error') ??
+  (__DEV__ ? 'debug' : 'info');
+
+export const log = logger.createLogger({
+  severity,                 
+  transport: consoleTransport,
+  printLevel: true,
+  printDate: true,
+  transportOptions: {
+    colors: {
+      debug: 'grey',
+      info:  'cyan',
+      warn:  'yellow',
+      error: 'red',
+    },
+  },
+});
+
+export const createScopedLog = (scope: string) => ({
+  debug: (m: string, d?: unknown) => log.debug(`${scope}: ${m}`, d),
+  info:  (m: string, d?: unknown) => log.info(`${scope}: ${m}`, d),
+  warn:  (m: string, d?: unknown) => log.warn(`${scope}: ${m}`, d),
+  error: (m: string, d?: unknown) => log.error(`${scope}: ${m}`, d),
+});
+
+


### PR DESCRIPTION
## Description

Initial Expo App Setup #36

This PR introduces a standardized logging utility for the Expo app:

1. Uses react-native-logs with consoleTransport.
2. Adds colored output.
3. Reads minimum severity from EXPO_PUBLIC_LOG_LEVEL (falls back to debug in dev, info in prod).
4. Adds Jest tests for configuration and forwarding.

---

## Usage Example
```
// Any module file
import { createScopedLog } from '@/utils/logger';

const log = createScopedLog('feature.example'); // pick a clear scope

// simple info
log.info('starting operation');

// with metadata
log.debug('fetching resources', { page: 1, pageSize: 20 });

// timing + levels
const t0 = Date.now();
try {
  // ... do work
  log.info('operation succeeded', { tookMs: Date.now() - t0 });
} catch (err: any) {
  log.error('operation failed', { message: err?.message, tookMs: Date.now() - t0 });
}

// optional warnings
log.warn('retry scheduled', { attempt: 2, delayMs: 5000 });
```

---

## How was this tested?

Unit tests (Jest)
* [x] Mocked react-native-logs to assert createLogger is called with env severity.
* [x] Verified log.info/warn/error/debug forward to the underlying instance.

---

## Checklist

* [x] npm i react-native-logs added
* [x] app/utils/logger.ts created 
* [x]  Jest tests added and pass locally (npm test)

---

## Screenshots
<img width="628" height="371" alt="Screenshot 2025-09-29 at 7 13 24 PM" src="https://github.com/user-attachments/assets/1481dd41-82ff-4bfd-bc98-4c09ea189416" />
