### PR TITLE
added personas

### DIFF
--- a/Documentation/Mockups/persona.md
+++ b/Documentation/Mockups/persona.md
@@ -1,0 +1,234 @@
+## a. Personas
+### Persona 1:
+<img width="415" height="831" alt="image" src="https://github.com/user-attachments/assets/7be65c6a-3ae9-4122-8d2f-5ba4df174859" />
+
+1. Name: Sarah Mendes
+2. Role: League Manager (Community Sports Organizer)
+3. Problems:
+   - Manually coordinating players, venues, and schedules wastes time.
+   - Communication is separated through different tools (WhatsApp, email, spreadsheets).
+   - Roles and responsibilities in teams are not clear or not managed well.
+
+4. Pains:
+   - Double bookings or miscommunications cause public embarrassment.
+   - Players complain about last-minute changes and lack of updates.
+   - Burnout from repetition of admin work, especially doing the same work with multiple leagues.
+
+5. Goals:
+   - Run a smooth and professional league with minima overhead that is manual.
+   - Build a system that is reliable by scaling across seasons and teams.
+   - Focus more on community engagement and less on admin tasks.
+
+6. **Motivations:**
+   - Passionate about community sports and wants leagues to feel organized and fun.
+   - Wants to be known as a capable and trusted organizer in her community.
+   - Driven by pride in running well-organized events that players love coming back to.
+   - Wants tools that make her role easier without having to need constant tech support.
+
+7. Desired Benefits:
+   - Save hours each week with scheduling and communication that are centralized.
+   - Avoid chaos and complaints by having players trusting her systems.
+   - Gain peace of mind knowing everything is under control and easy to access.
+
+8. Objections:
+   - Doubts that a new platform will be worth the learning curve.
+   - Worries that older or less tech-savvy participants won’t adopt it.
+   - Hesitates to switch mid-season due to potential disruptions.
+
+9. Context:
+   - She’s resourceful and tech-aware but not a tech expert.
+   - Uses a mix of Google Sheets, WhatsApp, Facebook groups and PDFs.
+   - Has tried apps like TeamSnap but found them limited to team-level management.
+
+10. Triggers:
+   - A major scheduling error or unhappy team escalates frustrations.
+   - A colleague recommends a new platform that "just works."
+   - A new season is starting and she wants to improve the process.
+---
+
+### Persona 2:
+<img width="415" height="831" alt="image" src="https://github.com/user-attachments/assets/6f7a15be-3c0f-474b-a5f7-d83eda317fba" />
+
+1. Name: Jordan Lee
+2. Role: Team Player (Amateur Athlete, Weekend League)
+3. Problems:
+   - Often confused about when and where games are.
+   - Doesn’t get timely updates when schedules or teams change.
+   - Lacks visibility into team communication, performance or responsibilities.
+   
+4. Pains:
+   - Misses games or arrives late because of unclear communication.
+   - Feels disconnected from team decisions or logistics.
+   - Wastes time scrolling through group chats looking for info.
+
+5. Goals:
+   - Know exactly when and where to be for every game.
+   - Stay updated on team news, changes and roles.
+   - Contribute to the team and feel involved without extra admin work.
+
+6. Motivations:
+   - Plays to stay fit, have fun and bond with teammates.
+   - Takes pride in being reliable and showing up prepared.
+   - Wants to feel like part of an organized team, not just a body on the field.
+   - Motivated by seeing progress, stats or recognition for their contributions.
+
+7. Desired Benefits:
+   - Easy access to upcoming games, team roster and league standings.
+   - Centralized updates and notifications (no more digging through chats).
+   - Less confusion, fewer no-shows and team coordination that is smoother.
+
+8. Objections:
+   - Won’t use something if it feels like too much effort or another app to download.
+   - Avoids platforms that look “too corporate” or overcomplicated.
+   - Skeptical if teammates don’t all commit to using it too.
+
+9. Context:
+   - Uses apps like WhatsApp, Instagram and calendar reminders to stay updated.
+   - Not heavily involved in team management (just wants clean and quick access to info).
+   - May play in multiple leagues or teams, which adds confusion.
+
+10. Triggers:
+   - Misses a game or arrives at the wrong venue because of miscommunication.
+   - Coach/Manager introduces a new tool and asks everyone to join.
+   - Starts a new season and wants to stay more on top of things.
+
+---
+
+### Persona 3:
+<img width="415" height="831" alt="image" src="https://github.com/user-attachments/assets/0d79c4b3-0494-448c-880a-a72ebfbc231d" />
+
+1. Name: Amina Tremblay
+2. Role: Casual Browser (Community Member, Local Sports Enthusiast)
+3. Problems:
+   - Hard to find local sports events or leagues to follow or join casually.
+   - No central place to explore local amateur sports schedules, updates or highlights.
+   - Existing league websites or tools are outdated, clunky, or not mobile-friendly.
+
+4. Pains:
+   - Feels left out of local sports unless she’s already “in the loop.”
+   - Gets interested in a league or event too late—after registration or season start.
+   - Often finds incomplete or outdated information when searching online.
+
+5. Goals:
+   - Discover local sports leagues and games happening nearby.
+   - Learn more about how to get involved as a fan, volunteer or future player.
+   - Easily browse teams, standings or game times.
+
+6. Motivations:
+   - Loves supporting local teams and community events.
+   - Looking for ways to stay socially connected, maybe join later.
+   - Finds joy in casual spectating and being part of a lively sports scene that is organized.
+   - May be considering enrolling a child or friend in a league and wants to explore first.
+
+7. Desired Benefits:
+   - Easy and intuitive browsing without account creation or commitment.
+   - Clean access to game schedules, team profiles and league standings.
+   - Confidence that the info is up-to-date and relevant to her location.
+
+8. Objections:
+   - Won’t engage if browsing is gated or has clunky interfaces.
+   - Loses trust if info looks outdated, inaccurate or inconsistent.
+   - Avoids platforms that look “too much like admin tools” or too focused on players only.
+
+9. Context:
+   - Stumbles upon GameOn through word of mouth, local event promotion or shared links.
+   - Often uses mobile, not desktop, for browsing.
+   - May casually follow multiple local sports scenes like basketball, soccer, basball, etc.
+
+10. Triggers:
+   - Sees a game happening nearby and wonders how to learn more or attend.
+   - A friend sends a link to check out a league or upcoming event.
+   - Actively looking for local leagues to join or enroll someone in.
+
+---
+
+### Persona 4:
+<img width="415" height="831" alt="image" src="https://github.com/user-attachments/assets/c40a5802-9a8d-4ace-81eb-c7a484964c5a" />
+
+1. Name: Carlos Johnson
+2. Role: Platform Admin (System Moderator & User Support for GameOn)
+3. Problems:
+   - Has to manually resolve user issues like login problems, abuse reports or data inconsistencies.
+   - Struggles with unclear visibility into league or user behaviour across the platform.
+   - Receives vague or incomplete issue reports with no tools to quickly trace root causes.
+
+4. Pains:
+   - Constant interruptions from repetitive user tickets.
+   - Pressure from both users and stakeholders to keep the platform stable, secure and fair.
+   - Lacks a clear dashboard or automated alerts when something’s going wrong.
+
+5. Goals:
+   - Maintain the integrity, reliability and fairness of the platform.
+   - Resolve user issues quickly and efficiently.
+   - Ensure smooth onboarding, access management and content moderation.
+
+6. Motivations:
+   - Feels ownership of the platform’s stability and user satisfaction.
+   - Wants to be proactive by fixing things before they become user complaints.
+   - Takes pride in being a “ghost hero” (invisible to most users, but essential to their experience).
+   - Enjoys building efficient systems and processes that reduce manual work over time.
+
+7. Desired Benefits:
+   - Access to robust admin dashboards with trails, usage logs and user reports.
+   - Tools to manage permissions, deactivate abusive users and resolve disputes.
+   - Automation for routine tasks (like verifying accounts, flagging suspicious activity).
+
+8. Objections:
+   - Dislikes platforms with limited backend visibility or no admin tooling.
+   - Worried of systems with poor error messaging or vague bug reports.
+   - Frustrated by a dev team that deprioritizes admin experience.
+
+9. Context:
+   - Likely a technical or semi-technical person with a background in QA or IT.
+   - Collaborates with developers, product managers and sometimes legal or compliance.
+   - Uses tools like Slack, Jira and internal dashboards to track and resolve issues.
+
+10. Triggers:
+   - A wave of user complaints about a bug or outage.
+   - A serious abuse or harassment report from within a league.
+   - A new feature rollout that requires backend oversight and support.
+
+
+***
+
+
+## b. Mockups
+
+**Team Creation, Post, Overview, Games and Board Page**
+
+Associated persona: Jordan Lee (Team Player) & Carlos Johnson (Platform Admin)
+
+
+<img width="1200" height="1000" alt="image" src="https://github.com/user-attachments/assets/521db88c-ad5f-4627-bcec-cfbe6b8c1139" />
+
+---
+
+**League Creation, Settings, Overview and Roles & Permissions Page**
+
+
+Associated persona: Sarah Mendes (League Manager), Jordan Lee (Team Player) & Carlos Johnson (Platform Admin)
+
+
+<img width="967" height="924" alt="Screenshot 2025-11-05 at 8 09 21 PM" src="https://github.com/user-attachments/assets/293824bc-1865-4ed4-a040-a351f87b939e" />
+
+---
+
+**Home Page, Browse Page & Search**
+
+
+Associated persona: Sarah Mendes (League Manager), Jordan Lee (Team Player), Amina Tremblay (Casual Browser) & Carlos Johnson (Platform Admin)
+
+
+<img src="https://github.com/user-attachments/assets/71bb2dce-0cf1-40c2-b104-6d12bdbedbf4" />
+
+---
+
+**Welcome Page, Login & Create Account**
+
+
+Associated persona: Sarah Mendes (League Manager), Jordan Lee (Team Player), Amina Tremblay (Casual Browser) & Carlos Johnson (Platform Admin)
+
+
+<img src="https://github.com/user-attachments/assets/69ab2a3c-8419-40d7-844e-2e4aadcab7fa" />
+
+


### PR DESCRIPTION
Linked issue: [#113 – Personas & Mockups](https://github.com/SoenCapstone/GameOn/issues/113)

## Description
This PR adds detailed **Personas** for the *GameOn* application as part of **Technical Design (Task 3.2)**.  
These personas represent key user types and their motivations, helping guide UI and UX decisions for the mockup phase.

### Contributions
- **Personas designed by:** @AsimRahman88  
- **Mockups designed by:** @mavmoud @Kayram2710 @Mariapalan @laraxl  
- **References:** ChatGPT and [userpersona.dev](https://userpersona.dev)  

### Changes Included
- Added detailed personas in:  
  `Documentation/Mockups/persona.md`  
- Updated the Wiki page: [ Personas and Mockups](https://github.com/SoenCapstone/GameOn/wiki/UI-Mockups#a-personas)  
  - Includes 4 primary user personas (League Manager, Team Player, Casual Browser and Platform Admin)  
  - Each persona includes goals, frustrations and core behaviours  
- Linked each persona to corresponding UI mockups for traceability between design and user needs  

---

## Acceptance Criteria
- [x] Personas include clear goals, motivations, and primary scenarios  
- [x] Mockups are uploaded and linked from the Wiki  
- [x] Each mockup is associated with at least one persona  
- [ ] Design rationale is briefly explained for each mockup  

