### PR TITLE
GO-135: Added axios request interceptor and fixed sign-up mutation fu…

### DIFF
--- a/GameOn-Frontend/app/(tabs)/profile/backendConnectionTest.tsx
+++ b/GameOn-Frontend/app/(tabs)/profile/backendConnectionTest.tsx
@@ -1,39 +1,25 @@
-/* Uncomment the component to test the backend connection in local */
+/* Note that this code is used to the test a backend connection  & is not an actual component */
 
-// export const BACKEND_TEST = (getToken) => {
-//   return (
-//     <Button
-//       title="test backend"
-//       onPress={async () => {
-//         console.log(process.env.EXPO_PUBLIC_API_BASE_URL);
+import { Button } from "react-native";
+import {
+  GO_USER_SERVICE_ROUTES,
+  useAxiosWithClerk,
+} from "@/hooks/use-axios-clerk";
+import { useMutation } from "@tanstack/react-query";
 
-//         const token = await getToken();
+export const BACKEND_TEST = () => {
+  const backendTestMutate = useBackendTestMutate();
+  return (
+    <Button title="test backend" onPress={() => backendTestMutate.mutate()} />
+  );
+};
 
-//         console.log(token);
+const useBackendTestMutate = () => {
+  const api = useAxiosWithClerk();
 
-//         const base64Url = token?.split(".")[1];
-//         const base64 = base64Url?.replace(/-/g, "+").replace(/_/g, "/");
-//         const jsonPayload = JSON.parse(atob(base64));
-
-//         console.log("iss:", jsonPayload.iss);
-//         console.log("aud:", jsonPayload.aud);
-
-//         const res = await fetch(
-//           `${process.env.EXPO_PUBLIC_API_BASE_URL}/api/v1/user/test`,
-//           {
-//             method: "POST",
-//             headers: {
-//               "Content-Type": "application/json",
-//               Authorization: `Bearer ${token}`,
-//             },
-//             body: JSON.stringify({ ping: "pong" }),
-//           }
-//         );
-
-//         const text = await res.text();
-//         console.log("Status:", res.status);
-//         console.log("Response:", text);
-//       }}
-//     />
-//   );
-// };
+  return useMutation({
+    mutationFn: async () => (await api.post(GO_USER_SERVICE_ROUTES.TEST)).data,
+    onSuccess: (data) => console.log(data),
+    onError: (error) => console.log(error),
+  });
+};

--- a/GameOn-Frontend/app/(tabs)/profile/index.tsx
+++ b/GameOn-Frontend/app/(tabs)/profile/index.tsx
@@ -8,7 +8,6 @@ import ContentArea from "@/components/content-area";
 export default function Profile() {
   const { signOut } = useAuth();
   const router = useRouter();
-  // const { getToken } = useAuth();
 
   return (
     <ContentArea>
@@ -19,7 +18,8 @@ export default function Profile() {
           title="Go to Feature Flags"
           onPress={() => router.push("/flags")}
         />
-        {/* <BACKEND_TEST getToken={getToken} /> */}
+        {/* Uncomment the component to test backend connection */}
+        {/* <BACKEND_TEST /> */}
         <Button
           title="Sign out"
           onPress={async () => {

--- a/GameOn-Frontend/components/sign-up/constants.ts
+++ b/GameOn-Frontend/components/sign-up/constants.ts
@@ -71,4 +71,7 @@ export const signUpInputLabels = (showPassword : boolean) => [
 ]
 
 export const EMAIL_VERIFICATION_STATUS = 'complete';
+export const SIGN_UP_SUCCESS_MESSAGE = "Profile created successfully!";
+export const SIGN_UP_CLERK_ERROR_MESSAGE = 'Clerk is not loaded or user is not signed in';
+export const SIGN_UP_BACKEND_ERROR_MESSAGE = "Error while creating profile! Please try again"
 

--- a/GameOn-Frontend/components/sign-up/utils.ts
+++ b/GameOn-Frontend/components/sign-up/utils.ts
@@ -89,16 +89,13 @@ export const completeVerificationAndUpsert = async (values: User, isLoaded : boo
     if (attempt.status === EMAIL_VERIFICATION_STATUS) {
       await setActive({ session: attempt.createdSessionId });
       
-      try {
       await upsertUser.mutateAsync({
-        id: attempt.createdUserId,
+        id: attempt?.createdUserId,
         email: values.emailAddress,
         firstname: values.firstname,
         lastname: values.lastname,
       });
-    } catch (err) {
-      console.error("Error connecting to BE", err);
-    }
+
     } else {
       Alert.alert('Verification incomplete', 'Please complete the required steps.');
     }

--- a/GameOn-Frontend/constants/hook-constants.ts
+++ b/GameOn-Frontend/constants/hook-constants.ts
@@ -1,0 +1,1 @@
+export const AXIOS_BEARER = 'Bearer';

--- a/GameOn-Frontend/hooks/__tests__/use-axios-clerk.test.ts
+++ b/GameOn-Frontend/hooks/__tests__/use-axios-clerk.test.ts
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+const mockUseAuth = jest.fn();
+jest.mock('@clerk/clerk-expo', () => ({
+	useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('axios', () => {
+	let savedOnFulfilled: any = null;
+	const mockUseLocal = (onFulfilled: any) => {
+		savedOnFulfilled = onFulfilled;
+		return 1;
+	};
+
+	const instance = {
+		interceptors: {
+			request: {
+				use: mockUseLocal,
+			},
+		},
+	};
+
+		const create = jest.fn(() => instance);
+		const defaultExport = { create };
+		return {
+			default: defaultExport,
+			create,
+			__getSavedOnFulfilled: () => savedOnFulfilled,
+			__esModule: true,
+		};
+});
+
+import { AXIOS_BEARER } from '@/constants/hook-constants';
+import { useAxiosWithClerk } from '@/hooks/use-axios-clerk';
+
+function TestComp() {
+	useAxiosWithClerk();
+	return null;
+}
+
+beforeEach(() => {
+	jest.clearAllMocks();
+});
+
+test('attaches interceptor and sets Authorization header when token exists', async () => {
+	const getToken = jest.fn().mockResolvedValue('token-123');
+	mockUseAuth.mockReturnValue({ getToken });
+
+		render(React.createElement(TestComp));
+
+		const axios = require('axios');
+		expect(axios.create).toHaveBeenCalledWith({ baseURL: process.env.EXPO_PUBLIC_API_BASE_URL });
+
+		const saved = axios.__getSavedOnFulfilled();
+		expect(typeof saved).toBe('function');
+
+		const config: any = { headers: {} };
+		await saved(config);
+
+	expect(config.headers.Authorization).toBe(`${AXIOS_BEARER} token-123`);
+});
+
+test('attaches interceptor and does not set Authorization when no token', async () => {
+	const getToken = jest.fn().mockResolvedValue(null);
+	mockUseAuth.mockReturnValue({ getToken });
+
+		render(React.createElement(TestComp));
+
+		const axios = require('axios');
+		expect(axios.create).toHaveBeenCalled();
+
+		const saved = axios.__getSavedOnFulfilled();
+		const config: any = { headers: {} };
+		await saved(config);
+	expect(config.headers.Authorization).toBeUndefined();
+});
+


### PR DESCRIPTION
## Description
1.  Created and `axios` instance containing a request interceptor allowing to append the clerk token to the request header.
2.  Replaced the `sign-up` and `backendtest` fetch functions to an `axios` alternative.
3.  Added implementation blocking an account from being created inside of  clerk but not in backend. Accounts can no longer be in an invalid state. If an account is created in clerk but refused from the backend, an `onError` function will delete the account from clerk.

## How was this tested? 
[x] Unit test
[x] manual test (see screenshot)

**Screenshots/media**
1. User account gets deleted from clerk  in the scenario where account creation passes the clerk step  but fails for backend.

https://github.com/user-attachments/assets/e5fdc854-e987-41bd-85c4-6b090d602e00

