### PR TITLE
[fix] updated api gateway's test

### DIFF
--- a/Backend/go-api-gateway/src/test/java/com/game/on/go_api_gateway/GoApiGatewayApplicationTests.java
+++ b/Backend/go-api-gateway/src/test/java/com/game/on/go_api_gateway/GoApiGatewayApplicationTests.java
@@ -2,9 +2,21 @@ package com.game.on.go_api_gateway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.mockito.Mockito;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 
 @SpringBootTest
 class GoApiGatewayApplicationTests {
+
+	@TestConfiguration
+	static class TestConfig {
+		@Bean
+		public ReactiveJwtDecoder jwtDecoder() {
+			return Mockito.mock(ReactiveJwtDecoder.class);
+		}
+	}
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
This PR fixed the outdated test of the api gateway

Before:

<img width="756" height="449" alt="Screenshot 2025-11-30 at 9 03 09 PM" src="https://github.com/user-attachments/assets/e5f219a2-aacc-4df6-acac-acbdfff6d1a6" />

---

After:

<img width="758" height="88" alt="Screenshot 2025-11-30 at 9 05 05 PM" src="https://github.com/user-attachments/assets/0bac3940-6ea3-45b8-a17d-fae3e57251fe" />
