### PR TITLE
feat(team-service): integrate OpenFeign user client with security con…

### DIFF
--- a/Backend/go-config-server/src/main/resources/configurations/go-league-service.yml
+++ b/Backend/go-config-server/src/main/resources/configurations/go-league-service.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/gameon_db
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    username: username
+    password: password
     driver-class-name: org.postgresql.Driver
   jpa:
     database: postgresql

--- a/Backend/go-league-service/pom.xml
+++ b/Backend/go-league-service/pom.xml
@@ -86,6 +86,28 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-openfeign-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.game.on</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/client/UserClient.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/client/UserClient.java
@@ -1,0 +1,16 @@
+package com.game.on.go_league_service.client;
+
+import com.game.on.go_league_service.config.FeignAuthForwardingConfig;
+import com.game.on.common.dto.UserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "go-user-service",
+        configuration = FeignAuthForwardingConfig.class
+)
+public interface UserClient {
+    @GetMapping("/api/v1/user/id/{userId}")
+    UserResponse getUserById(@PathVariable String userId);
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/config/CurrentUserProvider.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/config/CurrentUserProvider.java
@@ -1,0 +1,26 @@
+package com.game.on.go_league_service.config;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * Component to provide information about the currently authenticated user.
+ * It retrieves the user ID from the JWT token present in the security context allowing to avoid passing user IDs
+ * explicitly in service methods.
+ */
+@Component
+public class CurrentUserProvider {
+
+    public String clerkUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !(auth.getPrincipal() instanceof Jwt jwt)) {
+            throw new RuntimeException("No authenticated JWT found");
+        }
+
+        return jwt.getSubject();
+    }
+}
+

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/config/FeignAuthForwardingConfig.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/config/FeignAuthForwardingConfig.java
@@ -1,0 +1,26 @@
+package com.game.on.go_league_service.config;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignAuthForwardingConfig {
+
+    @Bean
+    public RequestInterceptor authForwardingInterceptor() {
+        return template -> {
+            var attrs = RequestContextHolder.getRequestAttributes();
+
+            if (attrs instanceof ServletRequestAttributes servletAttrs) {
+                String authHeader = servletAttrs.getRequest().getHeader("Authorization");
+
+                if (authHeader != null && !authHeader.isBlank()) {
+                    template.header("Authorization", authHeader);
+                }
+            }
+        };
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/config/SecurityConfig.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.game.on.go_league_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
related issue: #186 
## Summary
This PR integrates OpenFeign into the league microservice to enable secure communication with the user service.

## Changes
- Added `UserClient` using OpenFeign for user-service calls
- Implemented security context propagation for Feign requests
- Introduced `CurrentUserProvider` to access authenticated user details
- Added Feign auth forwarding configuration
- Updated security and JPA configuration as required


## Future Work
This PR is the **first step** toward a larger refactor of the league microservice planned for **next spring**, where the service will be reworked more deeply (architecture, responsibilities and internal logic).

## Notes
- No breaking changes
- Tested locally
