### PR TITLE
GH-221: Use per-service Flyway history tables for team and messaging

### DIFF
--- a/Backend/go-config-server/src/main/resources/configurations/go-messaging-service.yml
+++ b/Backend/go-config-server/src/main/resources/configurations/go-messaging-service.yml
@@ -17,6 +17,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 0
+    table: messaging_flyway_history
     locations: classpath:db/migration
   security:
     oauth2:

--- a/Backend/go-config-server/src/main/resources/configurations/go-team-service.yml
+++ b/Backend/go-config-server/src/main/resources/configurations/go-team-service.yml
@@ -17,6 +17,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 0
+    table: team_flyway_history
     locations: classpath:db/migration
     repair: true
 
@@ -39,4 +40,3 @@ management:
     web:
       exposure:
         include: health,info,metrics
-


### PR DESCRIPTION
## Description

Fix Flyway checksum conflicts between the team-service and messaging-service.

What I changed

- Updated go-team-service.yml to use its own Flyway history table (team_flyway_history).
- Updated go-messaging-service.yml to use its own Flyway history table (messaging_flyway_history).
Now each service tracks migrations separately instead of sharing flyway_schema_history.

## How to test:

1. Restart the config server.
2. Start team-service.
3. Start messaging-service.
4. Both services should start without Flyway checksum errors.