### PR TITLE
GO-212: Added PlayMaker poc

### DIFF
--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
@@ -1,5 +1,6 @@
 package com.game.on.go_team_service.team.controller;
 
+import com.game.on.common.dto.UserResponse;
 import com.game.on.go_team_service.team.dto.*;
 import com.game.on.go_team_service.team.service.TeamService;
 import jakarta.validation.Valid;
@@ -59,7 +60,7 @@ public class TeamController {
     }
 
     @GetMapping("/{teamId}/members")
-    public ResponseEntity<List<TeamMemberResponse>> listMembers(@PathVariable UUID teamId) {
+    public ResponseEntity<List<UserResponse>> listMembers(@PathVariable UUID teamId) {
         return ResponseEntity.ok(teamService.listMembers(teamId));
     }
 

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/service/TeamService.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/service/TeamService.java
@@ -208,10 +208,10 @@ public class TeamService {
     }
 
     @Transactional(readOnly = true)
-    public List<TeamMemberResponse> listMembers(UUID teamId) {
+    public List<UserResponse> listMembers(UUID teamId) {
         requireActiveTeam(teamId);
         return sortMembers(teamMemberRepository.findByTeamId(teamId)).stream()
-                .map(teamMapper::toMember)
+                .map((member) -> userClient.getUserById(member.getUserId()))
                 .toList();
     }
 

--- a/Frontend/__tests__/play-maker/clear-shapes-button.test.tsx
+++ b/Frontend/__tests__/play-maker/clear-shapes-button.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { ClearShapesButton } from "../../components/play-maker/clear-shapes-button";
+
+jest.mock("../../components/play-maker/play-maker-icon/icon-container", () => ({
+  IconContainer: () => null,
+}));
+
+const mockOnPressUndo = jest.fn();
+const mockOnPressClearCurrent = jest.fn();
+
+jest.mock("@/components/play-maker/model.ts", () => ({
+  CLEAR_SHAPES_BUTTON_CONFIG: [
+    { tool: "Undo", size: 24, xml: "<svg/>", onPress: mockOnPressUndo },
+    {
+      tool: "ClearCurrent",
+      size: 24,
+      xml: "<svg/>",
+      onPress: mockOnPressClearCurrent,
+    },
+  ],
+}));
+
+describe("ClearShapesButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders labels and triggers config onPress for each button", () => {
+    const setShapes = jest.fn();
+    const shapes = [{ id: "s1" }] as any;
+    const selectedShapeId = "s1";
+
+    const { getByText } = render(
+      <ClearShapesButton
+        setShapes={setShapes}
+        shapes={shapes}
+        selectedShapeId={selectedShapeId}
+      />
+    );
+
+    expect(getByText("Undo")).toBeTruthy();
+    expect(getByText("ClearCurrent")).toBeTruthy();
+  });
+});

--- a/Frontend/__tests__/play-maker/icon-container.test.tsx
+++ b/Frontend/__tests__/play-maker/icon-container.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { IconContainer } from "../../components/play-maker/play-maker-icon/icon-container";
+import { SvgXml } from "react-native-svg";
+
+jest.mock("react-native-svg", () => {
+  return {
+    SvgXml: jest.fn(() => null),
+  };
+});
+
+const mockedSvgXml = SvgXml as unknown as jest.Mock;
+
+describe("IconContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders SvgXml with xml and default size", () => {
+    const xml = "<svg></svg>";
+
+    render(<IconContainer xml={xml} />);
+
+    expect(mockedSvgXml).toHaveBeenCalledTimes(1);
+
+    const props = mockedSvgXml.mock.calls[0][0];
+    expect(props.xml).toBe(xml);
+    expect(props.width).toBe(32);
+    expect(props.height).toBe(32);
+  });
+
+  it("renders SvgXml with custom size", () => {
+    const xml = "<svg></svg>";
+
+    render(<IconContainer xml={xml} size={48} />);
+
+    expect(mockedSvgXml).toHaveBeenCalledTimes(1);
+
+    const props = mockedSvgXml.mock.calls[0][0];
+    expect(props.xml).toBe(xml);
+    expect(props.width).toBe(48);
+    expect(props.height).toBe(48);
+  });
+});

--- a/Frontend/__tests__/play-maker/play-maker-area.test.tsx
+++ b/Frontend/__tests__/play-maker/play-maker-area.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { PlayMakerArea } from "../../components/play-maker/play-maker-area";
+import { useGetTeamMembers } from "@/hooks/use-get-team-members/use-get-team-members";
+import { useRenderPlayMakerShapes } from "@/hooks/use-render-play-maker-shapes";
+
+jest.mock("@/hooks/use-get-team-members/use-get-team-members", () => ({
+  useGetTeamMembers: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-render-play-maker-shapes", () => ({
+  useRenderPlayMakerShapes: jest.fn(),
+}));
+
+jest.mock("@/components/play-maker/play-maker-board", () => ({
+  PlayMakerBoard: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock("@/components/play-maker/shapes-tab", () => ({
+  ShapesTab: () => null,
+}));
+
+jest.mock("@/components/play-maker/clear-shapes-button", () => ({
+  ClearShapesButton: () => null,
+}));
+
+let lastPanelProps: any = undefined;
+
+jest.mock("@/components/play-maker/player-assignment-panel", () => ({
+  PlayerAssignmentPanel: (props: any) => {
+    lastPanelProps = props;
+    return null;
+  },
+}));
+
+const mockedUseGetTeamMembers = useGetTeamMembers as jest.MockedFunction<
+  typeof useGetTeamMembers
+>;
+const mockedUseRenderPlayMakerShapes =
+  useRenderPlayMakerShapes as jest.MockedFunction<
+    typeof useRenderPlayMakerShapes
+  >;
+
+const makeProps = () =>
+  ({
+    styles: {
+      container: {},
+      boardWrapper: {},
+      shapeArea: {},
+      panelArea: {},
+    },
+    boardConfig: {} as any,
+  }) as any;
+
+describe("PlayMakerArea", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastPanelProps = undefined;
+    mockedUseRenderPlayMakerShapes.mockReturnValue([]);
+  });
+
+  it("shows loading indicator when team members are loading", () => {
+    mockedUseGetTeamMembers.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as any);
+
+    const { getByTestId } = render(<PlayMakerArea {...makeProps()} />);
+
+    expect(getByTestId("team-loading")).toBeTruthy();
+    expect(lastPanelProps).toBeUndefined();
+  });
+
+  it("renders PlayerAssignmentPanel when not loading and passes props", () => {
+    const data = [{ id: "1", name: "Alice" }];
+
+    mockedUseGetTeamMembers.mockReturnValue({
+      data,
+      isLoading: false,
+    } as any);
+
+    const { queryByTestId } = render(<PlayMakerArea {...makeProps()} />);
+
+    expect(queryByTestId("team-loading")).toBeNull();
+    expect(lastPanelProps).toBeDefined();
+    expect(lastPanelProps.data).toBe(data);
+    expect(lastPanelProps.selectedShapeId).toBe(null);
+    expect(Array.isArray(lastPanelProps.shapes)).toBe(true);
+    expect(typeof lastPanelProps.setShapes).toBe("function");
+  });
+});

--- a/Frontend/__tests__/play-maker/play-maker-board.test.tsx
+++ b/Frontend/__tests__/play-maker/play-maker-board.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import { PlayMakerBoard } from "../../components/play-maker/play-maker-board";
+
+jest.mock(
+  "../../components/play-maker/play-maker-board-configurations/play-maker-default-board",
+  () => ({
+    DefaultBoard: ({ children }: any) => <>{children}</>,
+  })
+);
+
+describe("PlayMakerBoard", () => {
+  it("renders children", () => {
+    const { getByText } = render(
+      <PlayMakerBoard
+        boardConfig={undefined as any}
+        selectedTool={"person" as any}
+        selectedShapeId={null}
+      >
+        <Text>Child</Text>
+      </PlayMakerBoard>
+    );
+
+    expect(getByText("Child")).toBeTruthy();
+  });
+
+  it("calls onBoardPress with locationX/locationY when pressed", () => {
+    const onBoardPress = jest.fn();
+
+    const { getByTestId } = render(
+      <PlayMakerBoard
+        onBoardPress={onBoardPress}
+        boardConfig={undefined as any}
+        selectedTool={"person" as any}
+        selectedShapeId={null}
+      >
+        <Text>Child</Text>
+      </PlayMakerBoard>
+    );
+
+    fireEvent.press(getByTestId("playmaker-board-pressable"), {
+      nativeEvent: { locationX: 12, locationY: 34 },
+    });
+
+    expect(onBoardPress).toHaveBeenCalledTimes(1);
+    expect(onBoardPress).toHaveBeenCalledWith({ x: 12, y: 34 });
+  });
+
+  it("does nothing if onBoardPress is not provided", () => {
+    const { getByTestId } = render(
+      <PlayMakerBoard
+        boardConfig={undefined as any}
+        selectedTool={"person" as any}
+        selectedShapeId={null}
+      >
+        <Text>Child</Text>
+      </PlayMakerBoard>
+    );
+
+    fireEvent.press(getByTestId("playmaker-board-pressable"), {
+      nativeEvent: { locationX: 1, locationY: 2 },
+    });
+  });
+});

--- a/Frontend/__tests__/play-maker/player-assignment-panel.test.tsx
+++ b/Frontend/__tests__/play-maker/player-assignment-panel.test.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent } from "@testing-library/react-native";
+import { PlayerAssignmentPanel } from "../../components/play-maker/player-assignment-panel";
+import { assignPlayerToShape } from "../../components/play-maker/utils";
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock("../../components/play-maker/utils", () => ({
+  assignPlayerToShape: jest.fn(),
+}));
+
+const mockedAssignPlayerToShape = assignPlayerToShape as jest.MockedFunction<
+  typeof assignPlayerToShape
+>;
+
+describe("PlayerAssignmentPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders member names", () => {
+    const data = [
+      { id: "m1", firstname: "Alice", lastname: "Smith" },
+      { id: "m2", firstname: "Bob", lastname: "Jones" },
+    ] as any;
+
+    const shapes = [] as any;
+    const setShapes = jest.fn();
+
+    const { getByText } = render(
+      <PlayerAssignmentPanel
+        data={data}
+        selectedShapeId={"shape-1"}
+        shapes={shapes}
+        setShapes={setShapes}
+      />
+    );
+
+    expect(getByText("Alice Smith")).toBeTruthy();
+    expect(getByText("Bob Jones")).toBeTruthy();
+  });
+
+  it("calls assignPlayerToShape with correct args when Assign is pressed", () => {
+    const data = [{ id: "m1", firstname: "Alice", lastname: "Smith" }] as any;
+
+    const shapes = [{ id: "shape-1" }] as any;
+    const setShapes = jest.fn();
+    const selectedShapeId = "shape-1";
+
+    const { getByLabelText } = render(
+      <PlayerAssignmentPanel
+        data={data}
+        selectedShapeId={selectedShapeId}
+        shapes={shapes}
+        setShapes={setShapes}
+      />
+    );
+
+    const button = getByLabelText("Assign Alice Smith to player icon");
+    fireEvent.press(button);
+
+    expect(mockedAssignPlayerToShape).toHaveBeenCalledTimes(1);
+    expect(mockedAssignPlayerToShape).toHaveBeenCalledWith(
+      "m1",
+      selectedShapeId,
+      shapes,
+      setShapes
+    );
+  });
+});

--- a/Frontend/__tests__/play-maker/shapes-tab.test.tsx
+++ b/Frontend/__tests__/play-maker/shapes-tab.test.tsx
@@ -1,0 +1,43 @@
+import { render, fireEvent } from "@testing-library/react-native";
+import { ShapesTab } from "../../components/play-maker/shapes-tab";
+
+jest.mock("../../components/play-maker/play-maker-icon/icon-container", () => ({
+  IconContainer: () => null,
+}));
+
+jest.mock("../../components/play-maker/model", () => ({
+  SELECT_SHAPE_BUTTON_CONFIG: [
+    { tool: "person", size: 24, xml: "<svg/>" },
+    { tool: "arrow", size: 24, xml: "<svg/>" },
+  ],
+}));
+
+describe("ShapesTab", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders labels for each tool in the config", () => {
+    const onSelectTool = jest.fn();
+
+    const { getByText } = render(
+      <ShapesTab selectedTool={"person" as any} onSelectTool={onSelectTool} />
+    );
+
+    expect(getByText("person")).toBeTruthy();
+    expect(getByText("arrow")).toBeTruthy();
+  });
+
+  it("calls onSelectTool(tool) when a tool is pressed", () => {
+    const onSelectTool = jest.fn();
+
+    const { getByTestId } = render(
+      <ShapesTab selectedTool={"person" as any} onSelectTool={onSelectTool} />
+    );
+
+    fireEvent.press(getByTestId("shape-tool-arrow"));
+
+    expect(onSelectTool).toHaveBeenCalledTimes(1);
+    expect(onSelectTool).toHaveBeenCalledWith("arrow");
+  });
+});

--- a/Frontend/__tests__/play-maker/use-render-play-maker-shapes.test.ts
+++ b/Frontend/__tests__/play-maker/use-render-play-maker-shapes.test.ts
@@ -1,0 +1,101 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react-native";
+import { Rect as SvgRect, Line, Path } from "react-native-svg";
+import { useRenderPlayMakerShapes } from "@/hooks/use-render-play-maker-shapes"; // adjust path
+import { Shape } from "@/components/play-maker/model";
+
+jest.mock("@/components/play-maker/play-maker-icon/icon-container", () => ({
+  IconContainer: (props: any) => null,
+}));
+
+
+describe("useRenderPlayMakerShapes", () => {
+  it("returns empty array when shapes is empty", () => {
+    const onSelect = jest.fn();
+
+    const { result } = renderHook<React.ReactElement[], unknown>(() =>
+      useRenderPlayMakerShapes([], null, onSelect)
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("renders a person shape and triggers onSelect when hitbox is pressed", () => {
+    const onSelect = jest.fn();
+
+    const shapes: Shape[] = [
+      {
+        type: "person",
+        id: "p1",
+        x: 100,
+        y: 200,
+        size: 28,
+      } as any,
+    ];
+
+    const { result } = renderHook<React.ReactElement[], unknown>(() =>
+      useRenderPlayMakerShapes(shapes, null, onSelect)
+    );
+
+    expect(result.current).toHaveLength(1);
+
+    const root = result.current[0] as React.ReactElement<any>;
+    const children = root.props.children as any[];
+
+    const hitRect = children.find((child) => child?.type === SvgRect);
+    expect(hitRect).toBeTruthy();
+
+    act(() => {
+      hitRect.props.onPress();
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("p1");
+  });
+
+  it("does not render arrow when from/to is missing", () => {
+    const onSelect = jest.fn();
+
+    const shapes: Shape[] = [{ type: "arrow", id: "a1" } as any];
+
+    const { result } = renderHook<React.ReactElement[], unknown>(() =>
+      useRenderPlayMakerShapes(shapes, null, onSelect)
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("renders arrow (Line + Path) and triggers onSelect when Line is pressed", () => {
+    const onSelect = jest.fn();
+
+    const shapes: Shape[] = [
+      {
+        type: "arrow",
+        id: "a1",
+        from: { x: 10, y: 20 },
+        to: { x: 110, y: 120 },
+      } as any,
+    ];
+
+    const { result } = renderHook<React.ReactElement[], unknown>(() =>
+      useRenderPlayMakerShapes(shapes, null, onSelect)
+    );
+
+    expect(result.current).toHaveLength(1);
+
+    const root = result.current[0] as React.ReactElement<any>;
+    const children = root.props.children as any[];
+
+    const line = children.find((c) => c?.type === Line);
+    const path = children.find((c) => c?.type === Path);
+
+    expect(line).toBeTruthy();
+    expect(path).toBeTruthy();
+
+    act(() => {
+      line.props.onPress();
+    });
+
+    expect(onSelect).toHaveBeenCalledWith("a1");
+  });
+});

--- a/Frontend/__tests__/play-maker/utils.test.ts
+++ b/Frontend/__tests__/play-maker/utils.test.ts
@@ -1,0 +1,280 @@
+import type { Shape } from "../../components/play-maker/model";
+import * as Crypto from "expo-crypto";
+import {
+  scanBoard,
+  hitTest,
+  addShapeAt,
+  addArrowBetweenShapes,
+  assignPlayerToShape,
+  isArrowSelectedOnBoard,
+} from "../../components/play-maker/utils";
+
+jest.mock("expo-crypto", () => ({
+  randomUUID: jest.fn(),
+}));
+
+jest.mock("../../components/play-maker/model", () => {
+  const actual = jest.requireActual("../../components/play-maker/model");
+  return {
+    ...actual,
+    SHAPE_CONFIG: {
+      person: {
+        create: ({ id, x, y }: any) => ({ id, type: "person", x, y, size: 28 }),
+      },
+      select: {
+        create: () => null, 
+      },
+      arrow: {
+        create: () => null,
+      },
+    },
+  };
+});
+
+const mockedRandomUUID = Crypto.randomUUID as unknown as jest.Mock;
+
+function makeSetState<T>(initial: T) {
+  let state = initial;
+  const setState = jest.fn((updater: any) => {
+    state = typeof updater === "function" ? updater(state) : updater;
+  });
+  return { getState: () => state, setState };
+}
+
+describe("play-maker utils", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("hitTest", () => {
+    it("returns the id of the top-most person when point is inside its hitbox", () => {
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 100, y: 100, size: 28 } as any,
+      ];
+
+      const id = hitTest(shapes, 100, 100);
+      expect(id).toBe("p1");
+    });
+
+    it("returns null when point is outside all shapes", () => {
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 100, y: 100, size: 28 } as any,
+      ];
+
+      const id = hitTest(shapes, 1000, 1000);
+      expect(id).toBeNull();
+    });
+
+    it("prefers the last shape in the array (top-most)", () => {
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 100, y: 100, size: 28 } as any,
+        { id: "p2", type: "person", x: 100, y: 100, size: 28 } as any, 
+      ];
+
+      const id = hitTest(shapes, 100, 100);
+      expect(id).toBe("p2");
+    });
+  });
+
+  describe("addShapeAt", () => {
+    it("adds a shape and selects it when tool creates a shape", () => {
+      mockedRandomUUID.mockReturnValueOnce("new-id");
+
+      const { getState, setState } = makeSetState<Shape[]>([]);
+      const setSelected = jest.fn();
+
+      addShapeAt(10, 20, "person" as any, setState as any, setSelected as any);
+
+      expect(setState).toHaveBeenCalledTimes(1);
+      expect(getState()).toEqual([
+        { id: "new-id", type: "person", x: 10, y: 20, size: 28 },
+      ]);
+
+      expect(setSelected).toHaveBeenCalledWith("new-id");
+    });
+
+    it("does not add anything and clears selection when tool creates null", () => {
+      mockedRandomUUID.mockReturnValueOnce("ignored");
+
+      const { getState, setState } = makeSetState<Shape[]>([
+        { id: "p1", type: "person", x: 1, y: 2 } as any,
+      ]);
+      const setSelected = jest.fn();
+
+      addShapeAt(10, 20, "select" as any, setState as any, setSelected as any);
+
+      expect(getState()).toEqual([{ id: "p1", type: "person", x: 1, y: 2 } as any]);
+      expect(setSelected).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("addArrowBetweenShapes", () => {
+    it("adds an arrow if both shapes exist and are endpoints", () => {
+      mockedRandomUUID.mockReturnValueOnce("arrow-id");
+
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 10, y: 20, size: 28 } as any,
+        { id: "p2", type: "person", x: 110, y: 120, size: 30 } as any,
+      ];
+
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+
+      addArrowBetweenShapes("p1", "p2", shapes, setState as any);
+
+      const next = getState();
+      expect(next).toHaveLength(3);
+
+      const arrow = next[2] as any;
+      expect(arrow.id).toBe("arrow-id");
+      expect(arrow.type).toBe("arrow");
+      expect(arrow.from).toMatchObject({ id: "p1", x: 10, y: 20, size: 28 });
+      expect(arrow.to).toMatchObject({ id: "p2", x: 110, y: 120, size: 30 });
+    });
+
+    it("does nothing if either shape is missing", () => {
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 10, y: 20 } as any,
+      ];
+
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+
+      addArrowBetweenShapes("p1", "missing", shapes, setState as any);
+
+      expect(getState()).toEqual(shapes);
+      expect(setState).not.toHaveBeenCalled();
+    });
+
+    it("does nothing if from/to is an arrow (not an endpoint)", () => {
+      const shapes: Shape[] = [
+        { id: "a1", type: "arrow", from: { x: 0, y: 0 }, to: { x: 1, y: 1 } } as any,
+        { id: "p2", type: "person", x: 10, y: 20 } as any,
+      ];
+
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+
+      addArrowBetweenShapes("a1", "p2", shapes, setState as any);
+
+      expect(getState()).toEqual(shapes);
+      expect(setState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("assignPlayerToShape", () => {
+    it("assigns playerId to the selected shape", () => {
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 0, y: 0 } as any,
+        { id: "p2", type: "person", x: 1, y: 1 } as any,
+      ];
+
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+
+      assignPlayerToShape("member-1", "p2", shapes, setState as any);
+
+      const next = getState() as any[];
+      expect(next.find((s) => s.id === "p2").associatedPlayerId).toBe("member-1");
+      expect(next.find((s) => s.id === "p1").associatedPlayerId).toBeUndefined();
+    });
+
+    it("does nothing if selectedShapeId is null", () => {
+      const shapes: Shape[] = [{ id: "p1", type: "person", x: 0, y: 0 } as any];
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+
+      assignPlayerToShape("member-1", null, shapes, setState as any);
+
+      expect(getState()).toEqual(shapes);
+      expect(setState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isArrowSelectedOnBoard", () => {
+    it("returns true if selectedShapeId points to an arrow", () => {
+      const shapes: Shape[] = [
+        { id: "a1", type: "arrow", from: { x: 0, y: 0 }, to: { x: 1, y: 1 } } as any,
+      ];
+
+      expect(isArrowSelectedOnBoard(shapes, "a1", null)).toBe(true);
+    });
+
+    it("returns true if hitId points to an arrow", () => {
+      const shapes: Shape[] = [
+        { id: "a1", type: "arrow", from: { x: 0, y: 0 }, to: { x: 1, y: 1 } } as any,
+      ];
+
+      expect(isArrowSelectedOnBoard(shapes, null, "a1")).toBe(true);
+    });
+
+    it("returns false if neither selectedShapeId nor hitId is an arrow id", () => {
+      const shapes: Shape[] = [{ id: "p1", type: "person", x: 0, y: 0 } as any];
+      expect(isArrowSelectedOnBoard(shapes, "p1", "p1")).toBe(false);
+    });
+  });
+
+  describe("scanBoard", () => {
+    it("if hit a shape and tool is select, selects that shape and does not add a new shape", () => {
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 100, y: 100, size: 28 } as any,
+      ];
+
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+      const setSelected = jest.fn();
+
+      scanBoard(
+        getState(),
+        100,
+        100,
+        "select" as any,
+        setState as any,
+        null,
+        setSelected as any
+      );
+
+      expect(setSelected).toHaveBeenCalledWith("p1");
+      expect(setState).not.toHaveBeenCalled(); // no new shapes added
+    });
+
+    it("if no hit, adds a shape at the point", () => {
+      mockedRandomUUID.mockReturnValueOnce("new-id");
+
+      const { getState, setState } = makeSetState<Shape[]>([]);
+      const setSelected = jest.fn();
+
+      scanBoard(
+        getState(),
+        10,
+        20,
+        "person" as any,
+        setState as any,
+        null,
+        setSelected as any
+      );
+
+      expect(getState()).toHaveLength(1);
+      expect(setSelected).toHaveBeenCalledWith("new-id");
+    });
+
+    it("if hit, tool is arrow, and selectedShapeId exists, adds arrow and selects hit shape", () => {
+      mockedRandomUUID.mockReturnValueOnce("arrow-id");
+
+      const shapes: Shape[] = [
+        { id: "p1", type: "person", x: 100, y: 100, size: 28 } as any,
+        { id: "p2", type: "person", x: 200, y: 200, size: 28 } as any,
+      ];
+
+      const { getState, setState } = makeSetState<Shape[]>(shapes);
+      const setSelected = jest.fn();
+
+      scanBoard(
+        getState(),
+        200,
+        200,
+        "arrow" as any,
+        setState as any,
+        "p1",
+        setSelected as any
+      );
+
+      expect(getState()).toHaveLength(3);
+      expect(setSelected).toHaveBeenCalledWith("p2");
+    });
+  });
+});

--- a/Frontend/__tests__/use-get-team-members.test.tsx
+++ b/Frontend/__tests__/use-get-team-members.test.tsx
@@ -1,0 +1,106 @@
+import { PropsWithChildren } from "react";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useGetTeamMembers } from "@/hooks/use-get-team-members/use-get-team-members";
+import { useAxiosWithClerk } from "@/hooks/use-axios-clerk";
+import { fetchTeamMembers } from "@/hooks/use-get-team-members/utils";
+
+jest.mock("@/hooks/use-axios-clerk", () => ({
+  useAxiosWithClerk: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-get-team-members/utils", () => ({
+  fetchTeamMembers: jest.fn(),
+}));
+
+const mockedUseAxiosWithClerk = useAxiosWithClerk as jest.MockedFunction<
+  typeof useAxiosWithClerk
+>;
+const mockedFetchTeamMembers = fetchTeamMembers as jest.MockedFunction<
+  typeof fetchTeamMembers
+>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useGetTeamMembers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls fetchTeamMembers with teamId and clerk axios client and returns data", async () => {
+    const teamId = "team-123";
+    const api = { get: jest.fn() } as any;
+
+    mockedUseAxiosWithClerk.mockReturnValue(api);
+
+    const members = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ] as any;
+
+    mockedFetchTeamMembers.mockResolvedValue(members);
+
+    const { result } = renderHook(() => useGetTeamMembers(teamId), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockedUseAxiosWithClerk).toHaveBeenCalledTimes(2);
+    expect(mockedFetchTeamMembers).toHaveBeenCalledTimes(1);
+    expect(mockedFetchTeamMembers).toHaveBeenCalledWith(teamId, api);
+    expect(result.current.data).toEqual(members);
+  });
+
+  it("exposes error when fetchTeamMembers rejects", async () => {
+    const teamId = "team-err";
+    const api = {} as any;
+
+    mockedUseAxiosWithClerk.mockReturnValue(api);
+
+    const err = new Error("boom");
+    mockedFetchTeamMembers.mockRejectedValue(err);
+
+    const { result } = renderHook(() => useGetTeamMembers(teamId), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockedFetchTeamMembers).toHaveBeenCalledWith(teamId, api);
+    expect(result.current.error).toBe(err);
+  });
+
+  it("uses the expected queryKey", async () => {
+    const teamId = "team-key";
+    const api = {} as any;
+
+    mockedUseAxiosWithClerk.mockReturnValue(api);
+    mockedFetchTeamMembers.mockResolvedValue([] as any);
+
+    const { result } = renderHook(() => useGetTeamMembers(teamId), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedFetchTeamMembers).toHaveBeenCalledWith(teamId, api);
+  });
+});

--- a/Frontend/app/(tabs)/spaces/index.tsx
+++ b/Frontend/app/(tabs)/spaces/index.tsx
@@ -1,11 +1,32 @@
-import React from "react";
 import { ContentArea } from "@/components/ui/content-area";
-import { View } from "react-native";
+// import { StyleSheet } from "react-native";
+// import { PlayMakerArea } from "@/components/play-maker/play-maker-area";
 
 export default function Spaces() {
   return (
     <ContentArea backgroundProps={{ preset: "purple" }}>
-      <View />
+      {/* <PlayMakerArea styles={styles} /> */}
+      <></>
     </ContentArea>
   );
 }
+
+/* Example of how to use the PlayMakerArea component */
+
+// const styles = StyleSheet.create({
+//   container: { flex: 1 },
+//   hint: {
+//     color: "white",
+//     opacity: 0.85,
+//     paddingTop: 10,
+//     paddingBottom: 8,
+//   },
+//   boardWrapper: { height: "50%" },
+//   shapeArea: {
+//     height: "7%",
+//     flexDirection: "row",
+//     justifyContent: "center",
+//     alignItems: "center",
+//   },
+//   panelArea: { height: "34%" },
+// });

--- a/Frontend/components/play-maker/clear-shapes-button.tsx
+++ b/Frontend/components/play-maker/clear-shapes-button.tsx
@@ -1,0 +1,70 @@
+import { Pressable, StyleSheet, View, Text } from "react-native";
+import { CLEAR_SHAPES_BUTTON_CONFIG, ClearShapesButtonProps } from "./model";
+import { IconContainer } from "./play-maker-icon/icon-container";
+
+export const ClearShapesButton = ({
+  setShapes,
+  shapes,
+  selectedShapeId,
+}: ClearShapesButtonProps) => {
+  return (
+    <View style={styles.container}>
+      {CLEAR_SHAPES_BUTTON_CONFIG.map((button) => (
+        <View key={button.tool}>
+          <Pressable
+            testID={`clear-shapes-${button.tool}`}
+            onPress={() => button.onPress(shapes, setShapes, selectedShapeId)}
+            style={({ pressed }) => [
+              styles.button,
+              pressed && styles.buttonPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="button"
+          >
+            <IconContainer size={button.size} xml={button.xml} />
+          </Pressable>
+          <Text numberOfLines={1} style={styles.label}>
+            {button.tool}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    gap: 10,
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 20,
+  },
+  label: {
+    alignSelf: "center",
+    paddingTop: 2,
+    fontSize: 10,
+    lineHeight: 12,
+    opacity: 0.85,
+    color: "white",
+    letterSpacing: 0.2,
+  },
+  button: {
+    alignSelf: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.25)",
+    backgroundColor: "rgba(0,0,0,0.15)",
+  },
+  buttonPressed: {
+    transform: [{ scale: 0.98 }],
+  },
+  buttonText: {
+    color: "white",
+    opacity: 0.85,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+});

--- a/Frontend/components/play-maker/model.ts
+++ b/Frontend/components/play-maker/model.ts
@@ -1,0 +1,111 @@
+import { TeamMember } from "@/hooks/use-get-team-members/model";
+import { UNDO_SVG, CLEAR_ALL_SVG, PERSON_SVG, LINE_SVG, REMOVE_CURRENT, COLOR_WHITE, SELECT_SVG } from "./play-maker-icon/constants";
+
+export type BoardConfigProps = {
+  children?: React.ReactNode;
+};
+
+export type PlayMakerAreaProps = {
+   boardConfig?: React.ComponentType<BoardConfigProps>;
+  styles: {
+    container: any;
+    boardWrapper: any;
+    shapeArea: any;
+    panelArea: any;
+  };
+};
+
+export type PlayMakerBoardProps = {
+    boardConfig?: React.ComponentType<BoardConfigProps>;
+  selectedTool: ShapeTool;
+  selectedShapeId?: string | null;
+  onBoardPress?: (pos: { x: number; y: number }) => void;
+  children?: React.ReactNode;
+};
+
+export type ShapesTabProps = {
+  selectedTool: ShapeTool;
+  onSelectTool: (tool: ShapeTool) => void;
+};
+
+export type ClearShapesButtonProps = {
+    shapes: Shape[];
+    setShapes: React.Dispatch<React.SetStateAction<Shape[]>>;
+    selectedShapeId?: string | null;
+}
+
+export type PlayerAssignmentPanelProps = {
+    data: TeamMember[] | undefined;
+    selectedShapeId: string | null;
+    shapes: Shape[];
+    setShapes: React.Dispatch<React.SetStateAction<Shape[]>>;
+}
+
+type ShapeMetadata = {
+  id: string;
+    x: number;
+    y: number;
+    size?: number
+};
+
+export type Shape =
+  | { id: string; type: "select"; x: number; y: number; r: number; associatedPlayerId?: string; from?: ShapeMetadata; to?: ShapeMetadata }
+  | { id: string; type: "arrow"; from?: ShapeMetadata; to?: ShapeMetadata; associatedPlayerId?: string }
+  | { id: string; type: "person"; x: number; y: number; size: number; associatedPlayerId?: string; from?: ShapeMetadata; to?: ShapeMetadata };
+
+export type EndpointShape = Exclude<Shape, { type: "arrow" }>;
+
+
+export type ShapeTool = Shape["type"];
+
+type CreateContext = { id: string; x: number; y: number };
+
+type ShapeConfigEntry<T extends ShapeTool> = {
+  type: T;
+  create: (ctx: CreateContext) => Extract<Shape, { type: T }> | null;
+};
+
+export const SELECT_SHAPE_BUTTON_CONFIG: { tool: ShapeTool; size: number; xml: string }[] = [
+  { tool: "select", size: 22, xml: SELECT_SVG.replace(/currentColor/g, COLOR_WHITE) },
+  { tool: "person", size: 22, xml: PERSON_SVG.replace(/currentColor/g, COLOR_WHITE) },
+  { tool: "arrow", size: 22, xml: LINE_SVG.replace(/currentColor/g, COLOR_WHITE) },
+];
+
+export const CLEAR_SHAPES_BUTTON_CONFIG = [
+    { tool: "Undo", size: 22, xml: UNDO_SVG.replace(/currentColor/g, COLOR_WHITE), 
+        onPress: (shapes: Shape[], setShapes: React.Dispatch<React.SetStateAction<Shape[]>>, selectedShapeId: string | null | undefined) => 
+            setShapes(shapes.slice(0, -1)) },
+    { tool: "Delete", size: 22, xml: REMOVE_CURRENT.replace(/currentColor/g, COLOR_WHITE), 
+        onPress: (shapes : Shape[], setShapes: React.Dispatch<React.SetStateAction<Shape[]>>, selectedShapeId: string | null | undefined) => 
+            setShapes(shapes.filter(shape => shape.id !== selectedShapeId)) },
+    { tool: "Reset", size: 22, xml: CLEAR_ALL_SVG.replace(/currentColor/g, COLOR_WHITE), 
+        onPress: ( shapes : Shape[], setShapes: React.Dispatch<React.SetStateAction<Shape[]>>,  selectedShapeId: string | null | undefined) => 
+            setShapes([])},
+];
+
+export const SHAPE_CONFIG: { [K in ShapeTool]: ShapeConfigEntry<K> } = {
+  select: {
+    type: "select",
+    create: () => null,
+  },
+  arrow: {
+    type: "arrow",
+    create: () => null,
+  },
+  person: {
+    type: "person",
+    create: ({ id, x, y }) => ({
+      id,
+      type: "person",
+      x,
+      y,
+      size: 32, 
+    }),
+  },
+};
+
+
+
+
+
+

--- a/Frontend/components/play-maker/play-maker-area.tsx
+++ b/Frontend/components/play-maker/play-maker-area.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { View, ActivityIndicator } from "react-native";
+import { PlayMakerBoard } from "@/components/play-maker/play-maker-board";
+import { ShapesTab } from "@/components/play-maker/shapes-tab";
+import type {
+  Shape,
+  ShapeTool,
+  PlayMakerAreaProps,
+} from "@/components/play-maker/model";
+import { scanBoard } from "@/components/play-maker/utils";
+import { useRenderPlayMakerShapes } from "@/hooks/use-render-play-maker-shapes";
+import { ClearShapesButton } from "@/components/play-maker/clear-shapes-button";
+import { PlayerAssignmentPanel } from "./player-assignment-panel";
+import { useGetTeamMembers } from "@/hooks/use-get-team-members/use-get-team-members";
+
+export const PlayMakerArea = ({
+  styles,
+  boardConfig: BoardConfig,
+}: PlayMakerAreaProps) => {
+  const [selectedTool, setSelectedTool] = useState<ShapeTool>("person");
+  const [selectedShapeId, setSelectedShapeId] = useState<string | null>(null);
+  const [shapes, setShapes] = useState<Shape[]>([]);
+
+  /* TODO: Use the team id extracted from a TeamContext when navigating into a Team */
+  const TEAM_TEST_ID = "c2662f38-141e-48ad-87b1-744af4b07da3";
+
+  const { data, isLoading } = useGetTeamMembers(TEAM_TEST_ID);
+  const renderedShapes = useRenderPlayMakerShapes(
+    shapes,
+    selectedShapeId,
+    (id) => setSelectedShapeId(id)
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.boardWrapper}>
+        <PlayMakerBoard
+          boardConfig={BoardConfig}
+          selectedTool={selectedTool}
+          selectedShapeId={selectedShapeId}
+          onBoardPress={({ x, y }) =>
+            scanBoard(
+              shapes,
+              x,
+              y,
+              selectedTool,
+              setShapes,
+              selectedShapeId,
+              setSelectedShapeId
+            )
+          }
+        >
+          {renderedShapes}
+        </PlayMakerBoard>
+      </View>
+
+      <View style={styles.shapeArea}>
+        <ShapesTab selectedTool={selectedTool} onSelectTool={setSelectedTool} />
+        <ClearShapesButton
+          shapes={shapes}
+          setShapes={setShapes}
+          selectedShapeId={selectedShapeId}
+        />
+      </View>
+      {isLoading ? (
+        <ActivityIndicator testID="team-loading" size="large" color="white" />
+      ) : (
+        <View style={styles.panelArea}>
+          <PlayerAssignmentPanel
+            data={data}
+            selectedShapeId={selectedShapeId}
+            shapes={shapes}
+            setShapes={setShapes}
+          />
+        </View>
+      )}
+    </View>
+  );
+};

--- a/Frontend/components/play-maker/play-maker-board-configurations/play-maker-default-board.tsx
+++ b/Frontend/components/play-maker/play-maker-board-configurations/play-maker-default-board.tsx
@@ -1,0 +1,9 @@
+import Svg, { Rect } from "react-native-svg";
+export const DefaultBoard = ({ children }: { children?: React.ReactNode }) => {
+  return (
+    <Svg width="100%" height="100%">
+      <Rect x={0} y={0} width="100%" height="100%" fill="rgba(0,0,0,0.15)" />
+      {children}
+    </Svg>
+  );
+};

--- a/Frontend/components/play-maker/play-maker-board.tsx
+++ b/Frontend/components/play-maker/play-maker-board.tsx
@@ -1,0 +1,39 @@
+import { View, StyleSheet, Pressable } from "react-native";
+import { PlayMakerBoardProps } from "./model";
+import { DefaultBoard } from "./play-maker-board-configurations/play-maker-default-board";
+
+export const PlayMakerBoard = ({
+  onBoardPress,
+  boardConfig: BoardConfig,
+  children,
+}: PlayMakerBoardProps) => {
+  const BoardWrapper = BoardConfig ?? DefaultBoard;
+
+  return (
+    <View style={styles.wrap}>
+      <Pressable
+        testID="playmaker-board-pressable"
+        style={styles.board}
+        onPress={(e) => {
+          if (!onBoardPress) return;
+          const { locationX, locationY } = e.nativeEvent;
+          onBoardPress({ x: locationX, y: locationY });
+        }}
+      >
+        <BoardWrapper>{children}</BoardWrapper>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1 },
+  board: {
+    flex: 1,
+    margin: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.25)",
+    overflow: "hidden",
+  },
+});

--- a/Frontend/components/play-maker/play-maker-icon/constants.ts
+++ b/Frontend/components/play-maker/play-maker-icon/constants.ts
@@ -1,0 +1,63 @@
+export const COLOR_WHITE = 'white';
+
+export const PERSON_SVG = `
+<svg
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"
+    fill="currentColor"
+  />
+  <path
+    d="M12 14c-4.42 0-8 2.24-8 5v1h16v-1c0-2.76-3.58-5-8-5z"
+    fill="currentColor"
+  />
+</svg>
+`;
+
+export const CLEAR_ALL_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
+  <path d="M120-280v-80h560v80H120Zm80-160v-80h560v80H200Zm80-160v-80h560v80H280Z"/>
+</svg>`;
+
+export const REMOVE_CURRENT = `
+<svg
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12Zm3-10h2v8H9V9Zm4 0h2v8h-2V9ZM15.5 4l-1-1h-5l-1 1H5v2h14V4h-3.5Z"
+    fill="currentColor"
+  />
+</svg>
+`;
+
+
+export const UNDO_SVG = `
+<svg
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M7 19v-2h7.1c1.58 0 2.87-.33 3.83-1s1.47-1.65 1.47-2.75c0-1.5-.62-2.5-1.86-3.06-.84-.38-1.95-.56-3.35-.56H7.8l2.6 2.6-1.4 1.4-5-5 5-5 1.4 1.4-2.6 2.6H14c2.43 0 4.29.53 5.56 1.58C20.86 10.29 21.5 11.7 21.5 13.25c0 2.05-.81 3.57-2.44 4.56C17.92 18.6 16.27 19 14.1 19H7Z"
+    fill="currentColor"
+  />
+</svg>
+`;
+
+export const SELECT_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
+  <path d="m320-410 79-110h170L320-716v306ZM551-80 406-392 240-160v-720l560 440H516l144 309-109 51ZM399-520Z"/>
+</svg>
+`;
+
+
+export const LINE_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
+  <path d="M704-240 320-624v344h-80v-480h480v80H376l384 384-56 56Z"/>
+</svg>
+`;
+
+
+

--- a/Frontend/components/play-maker/play-maker-icon/icon-container.tsx
+++ b/Frontend/components/play-maker/play-maker-icon/icon-container.tsx
@@ -1,0 +1,6 @@
+import { SvgXml } from "react-native-svg";
+import { IconProps } from "./model";
+
+export const IconContainer = ({ size = 32, xml }: IconProps) => {
+  return <SvgXml xml={xml} width={size} height={size} />;
+};

--- a/Frontend/components/play-maker/play-maker-icon/model.ts
+++ b/Frontend/components/play-maker/play-maker-icon/model.ts
@@ -1,0 +1,4 @@
+export type IconProps = {
+  size?: number;
+  xml: string;
+};

--- a/Frontend/components/play-maker/player-assignment-panel.tsx
+++ b/Frontend/components/play-maker/player-assignment-panel.tsx
@@ -1,0 +1,105 @@
+import { Text, Pressable, StyleSheet, View, ScrollView } from "react-native";
+import { Card } from "@/components/ui/card";
+import { PlayerAssignmentPanelProps } from "./model";
+import { assignPlayerToShape } from "./utils";
+
+export const PlayerAssignmentPanel = ({
+  data,
+  selectedShapeId,
+  shapes,
+  setShapes,
+}: PlayerAssignmentPanelProps) => {
+  return (
+    <ScrollView
+      style={{ flex: 1, paddingVertical: 10 }}
+      contentContainerStyle={{ flexGrow: 1 }}
+      keyboardShouldPersistTaps="handled"
+    >
+      <View style={styles.list}>
+        {data?.map((member) => {
+          const isMemberAssignedToShape = shapes?.filter(
+            (shape) =>
+              shape.associatedPlayerId === member.id &&
+              shape.id === selectedShapeId
+          ).length;
+          return (
+            <View
+              key={member.id}
+              style={[!!isMemberAssignedToShape && styles.cardWrapperAssigned]}
+            >
+              <Card>
+                <View style={styles.row}>
+                  <Text style={styles.name}>
+                    {member.firstname} {member.lastname}
+                  </Text>
+
+                  <Pressable
+                    onPress={() => {
+                      assignPlayerToShape(
+                        member.id,
+                        selectedShapeId,
+                        shapes,
+                        setShapes
+                      );
+                    }}
+                    style={({ pressed }) => [
+                      styles.assignButton,
+                      pressed && styles.assignButtonPressed,
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Assign ${member.firstname} ${member.lastname} to player icon`}
+                  >
+                    <Text style={styles.assignButtonText}>Assign</Text>
+                  </Pressable>
+                </View>
+              </Card>
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  list: {
+    gap: 10,
+  },
+  cardWrapperAssigned: {
+    borderRadius: 34,
+    overflow: "hidden",
+    borderColor: "rgba(0,255,120,0.85)",
+    borderWidth: 2,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  name: {
+    color: "white",
+    fontSize: 14,
+    fontWeight: "600",
+    opacity: 0.9,
+    flexShrink: 1,
+  },
+  assignButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.25)",
+    backgroundColor: "rgba(255,255,255,0.12)",
+  },
+  assignButtonPressed: {
+    transform: [{ scale: 0.98 }],
+    opacity: 0.95,
+  },
+  assignButtonText: {
+    color: "white",
+    fontSize: 13,
+    fontWeight: "700",
+    opacity: 0.95,
+  },
+});

--- a/Frontend/components/play-maker/shapes-tab.tsx
+++ b/Frontend/components/play-maker/shapes-tab.tsx
@@ -1,0 +1,90 @@
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { SELECT_SHAPE_BUTTON_CONFIG, ShapesTabProps } from "./model";
+import { IconContainer } from "./play-maker-icon/icon-container";
+
+export const ShapesTab = ({ selectedTool, onSelectTool }: ShapesTabProps) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        {SELECT_SHAPE_BUTTON_CONFIG?.map(({ tool, size, xml }) => {
+          const active = selectedTool === tool;
+
+          return (
+            <View key={tool}>
+              <Pressable
+                testID={`shape-tool-${tool}`}
+                onPress={() => onSelectTool(tool)}
+                style={({ pressed }) => [
+                  styles.button,
+                  active && styles.buttonActive,
+                  pressed && styles.buttonPressed,
+                ]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+              >
+                <IconContainer size={size} xml={xml} />
+              </Pressable>
+              <Text
+                numberOfLines={1}
+                style={[styles.label, active && styles.labelSelected]}
+              >
+                {tool}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 6,
+    alignItems: "center",
+    paddingBottom: 6,
+  },
+  label: {
+    alignSelf: "center",
+    paddingTop: 2,
+    fontSize: 10,
+    lineHeight: 12,
+    opacity: 0.85,
+    color: "white",
+    letterSpacing: 0.2,
+  },
+  labelSelected: {
+    opacity: 1,
+    fontWeight: "600",
+  },
+  row: {
+    flexDirection: "row",
+    gap: 10,
+    flexWrap: "wrap",
+  },
+  button: {
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.25)",
+    backgroundColor: "rgba(0,0,0,0.15)",
+  },
+  buttonActive: {
+    borderColor: "rgba(255,255,255,0.6)",
+    backgroundColor: "rgba(255,255,255,0.18)",
+  },
+  buttonPressed: {
+    transform: [{ scale: 0.98 }],
+  },
+  buttonText: {
+    color: "white",
+    opacity: 0.85,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  buttonTextActive: {
+    opacity: 1,
+  },
+});

--- a/Frontend/components/play-maker/utils.ts
+++ b/Frontend/components/play-maker/utils.ts
@@ -1,0 +1,124 @@
+import { Shape, ShapeTool, EndpointShape, SHAPE_CONFIG } from "./model";
+import * as Crypto from "expo-crypto";
+
+export const scanBoard = (
+  shapes: Shape[],
+  x: number,
+  y: number,
+  selectedTool: ShapeTool,
+  setShapes: React.Dispatch<React.SetStateAction<Shape[]>>,
+  selectedShapeId: string | null,
+  setSelectedShapeId: React.Dispatch<React.SetStateAction<string | null>>
+) => {
+  
+  const hitId = hitTest(shapes, x, y);
+  if (hitId) {
+    if(selectedTool === "arrow" && selectedShapeId &&  !isArrowSelectedOnBoard(shapes, selectedShapeId, hitId) && selectedShapeId !== hitId) {
+        addArrowBetweenShapes(selectedShapeId, hitId, shapes, setShapes);
+        setSelectedShapeId(hitId);
+    }
+    if(selectedTool === "select") {
+       setSelectedShapeId(hitId);
+    }
+    return;
+  }
+
+  addShapeAt(
+    x,
+    y,
+    selectedTool,
+    setShapes,
+    setSelectedShapeId
+  );
+};
+
+export const isArrowSelectedOnBoard = (shapes: Shape[], selectedShapeId: string | null, hitId: string | null): boolean => {
+  return !!(shapes.filter(shape => shape.type === "arrow" && selectedShapeId === shape.id).length || shapes.filter(shape => shape.type === "arrow" && hitId === shape.id).length);
+};
+
+export const hitTest = (shapes: Shape[], x: number, y: number): string | null => {
+  for (let i = shapes.length - 1; i >= 0; i--) {
+    const s = shapes[i];
+
+    if (s.type === "person") {
+      const size = s.size ?? 28;
+      const hitPadding = 8;
+      const left = s.x - size / 2 - hitPadding;
+      const top = s.y - size / 2 - hitPadding;
+      const w = size + hitPadding * 2;
+      const h = size + hitPadding * 2;
+
+      const inside = x >= left && x <= left + w && y >= top && y <= top + h;
+      if (inside) return s.id;
+    }
+
+  }
+
+  return null;
+}
+
+export const addShapeAt = (
+  x: number,
+  y: number,
+  selectedTool: ShapeTool,
+  setShapes: React.Dispatch<React.SetStateAction<Shape[]>>,
+  setSelectedShapeId: React.Dispatch<React.SetStateAction<string | null>>
+) => {
+  const id = Crypto.randomUUID();
+  const shape = SHAPE_CONFIG[selectedTool].create({ id, x, y });
+
+  if (!shape) {
+    setSelectedShapeId(null);
+    return;
+  }
+
+  setShapes((prev) => [...prev, shape]);
+  setSelectedShapeId(id);
+};
+
+export const addArrowBetweenShapes = (
+  fromId: string,
+  toId: string,
+  shapes: Shape[],
+  setShapes: React.Dispatch<React.SetStateAction<Shape[]>>,
+) => {
+  const fromShape = shapes.find((s) => s.id === fromId);
+  const toShape = shapes.find((s) => s.id === toId);
+
+  if (!fromShape || !toShape) return;
+  if (!isEndpointShape(fromShape) || !isEndpointShape(toShape)) return;
+
+  setShapes((prev) => [
+    ...prev,
+    {
+      id: Crypto.randomUUID(),
+      type: "arrow",
+      from: {
+        id: fromShape.id,
+        x: fromShape.x,
+        y: fromShape.y,
+        size: getEndpointSize(fromShape),
+      },
+      to: {
+        id: toShape.id,
+        x: toShape.x,
+        y: toShape.y,
+        size: getEndpointSize(toShape),
+      },
+    },
+  ]);
+};
+
+export const assignPlayerToShape = (playerId: string, selectedShapeId: string | null, shapes: Shape[], setShapes: React.Dispatch<React.SetStateAction<Shape[]>>) => {
+  if (!selectedShapeId || !shapes) return;
+
+  setShapes(prevShapes =>
+    prevShapes.map(shape =>
+      shape.id === selectedShapeId ? { ...shape, associatedPlayerId: playerId } : shape
+    )
+  );
+}
+
+const isEndpointShape = (shape: Shape): shape is EndpointShape => shape.type !== "arrow";
+
+const getEndpointSize = (shape: EndpointShape): number | undefined => shape.type === "person" ? shape.size : undefined;

--- a/Frontend/hooks/use-axios-clerk.ts
+++ b/Frontend/hooks/use-axios-clerk.ts
@@ -61,6 +61,8 @@ export const GO_USER_SERVICE_ROUTES = {
 export const GO_TEAM_SERVICE_ROUTES = {
   ALL: buildRoute(VERSIONING.v1, SERVICE.TEAMS),
   CREATE: buildRoute(VERSIONING.v1, SERVICE.TEAMS, "create"),
+  GET_TEAM_MEMBERS: (teamId: string) =>
+    buildRoute(VERSIONING.v1, SERVICE.TEAMS, `${teamId}/members`),
 };
 
 const messagingBase = buildRoute(VERSIONING.v1, SERVICE.MESSAGING);

--- a/Frontend/hooks/use-get-team-members/model.ts
+++ b/Frontend/hooks/use-get-team-members/model.ts
@@ -1,0 +1,6 @@
+export type TeamMember = {
+  email: string;
+  firstname: string;
+  id: string;
+  lastname: string;
+};

--- a/Frontend/hooks/use-get-team-members/use-get-team-members.ts
+++ b/Frontend/hooks/use-get-team-members/use-get-team-members.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosWithClerk } from "../use-axios-clerk";
+import { fetchTeamMembers } from "./utils";
+import { TeamMember } from "./model";
+
+export const useGetTeamMembers = (teamId: string) => {
+    const api = useAxiosWithClerk();
+    return useQuery<TeamMember[]>({
+        queryKey: ["team", teamId],
+        queryFn: async () => fetchTeamMembers(teamId, api),
+    }); 
+}

--- a/Frontend/hooks/use-get-team-members/utils.ts
+++ b/Frontend/hooks/use-get-team-members/utils.ts
@@ -1,0 +1,5 @@
+import { GO_TEAM_SERVICE_ROUTES } from "../use-axios-clerk";
+
+export const fetchTeamMembers =  (teamId: string, api: any) => {
+    return api.get(GO_TEAM_SERVICE_ROUTES.GET_TEAM_MEMBERS(teamId)).then((res: any) => res.data);
+}

--- a/Frontend/hooks/use-render-play-maker-shapes.tsx
+++ b/Frontend/hooks/use-render-play-maker-shapes.tsx
@@ -1,0 +1,127 @@
+import { useMemo } from "react";
+import { Shape } from "@/components/play-maker/model";
+import { Rect as SvgRect, Line, G, Path } from "react-native-svg";
+import { IconContainer } from "@/components/play-maker/play-maker-icon/icon-container";
+import { PERSON_SVG } from "@/components/play-maker/play-maker-icon/constants";
+
+type OnSelect = (id: string) => void;
+
+type RendererMap = {
+  [K in Shape["type"]]: (
+    shape: Extract<Shape, { type: K }>,
+    isSelected: boolean,
+    selectedShapeId: string | null,
+    onSelect: OnSelect
+  ) => React.ReactElement | null;
+};
+
+const renderers: RendererMap = {
+  select: () => null,
+
+  person: (s, isSelected, _selectedId, onSelect) => {
+    const size = s.size ?? 28;
+    const hitPadding = 8;
+
+    const left = s.x - size / 2;
+    const top = s.y - size / 2;
+
+    return (
+      <G key={s.id} transform={`translate(${left}, ${top})`}>
+        <SvgRect
+          x={-hitPadding}
+          y={-hitPadding}
+          width={size + hitPadding * 2}
+          height={size + hitPadding * 2}
+          fill="transparent"
+          onPress={() => onSelect(s.id)}
+        />
+
+        <IconContainer
+          size={isSelected ? size * 1.25 : size}
+          xml={PERSON_SVG.replace(
+            /currentColor/g,
+            isSelected ? "#4ade80" : "white"
+          )}
+        />
+      </G>
+    );
+  },
+
+  arrow: (s, isSelected, _selectedId, onSelect) => {
+    if (!s.from || !s.to) return null;
+
+    const stroke = isSelected ? "#4ade80" : "rgba(255,255,255,0.85)";
+    const strokeWidth = isSelected ? 4 : 3;
+
+    const x1 = s.from.x;
+    const y1 = s.from.y;
+    const x2 = s.to.x;
+    const y2 = s.to.y;
+
+    const d = buildArrowPath(x1, y1, x2, y2);
+
+    return (
+      <G key={s.id}>
+        <Line
+          x1={x1}
+          y1={y1}
+          x2={x2}
+          y2={y2}
+          stroke="transparent"
+          strokeWidth={isSelected ? 32 : 24}
+          onPress={() => onSelect(s.id)}
+        />
+
+        <Path
+          d={d}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </G>
+    );
+  },
+};
+
+export const useRenderPlayMakerShapes = (
+  shapes: Shape[],
+  selectedShapeId: string | null,
+  onSelect: OnSelect
+) => {
+  return useMemo(() => {
+    return shapes
+      .map((s) => {
+        const isSelected = "id" in s && s.id === selectedShapeId;
+        return renderers[s.type](
+          s as any,
+          isSelected,
+          selectedShapeId,
+          onSelect
+        );
+      })
+      .filter(Boolean) as React.ReactElement[];
+  }, [shapes, selectedShapeId, onSelect]);
+};
+
+const buildArrowPath = (
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  headLength = 14,
+  headAngle = Math.PI / 6
+) => {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+
+  const hx1 = x2 - headLength * Math.cos(angle - headAngle);
+  const hy1 = y2 - headLength * Math.sin(angle - headAngle);
+
+  const hx2 = x2 - headLength * Math.cos(angle + headAngle);
+  const hy2 = y2 - headLength * Math.sin(angle + headAngle);
+
+  return `M ${x1} ${y1} L ${x2} ${y2} 
+          M ${x2} ${y2} L ${hx1} ${hy1}
+          M ${x2} ${y2} L ${hx2} ${hy2}`;
+};

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -30,6 +30,7 @@
         "expo": "~54.0.25",
         "expo-blur": "~15.0.7",
         "expo-constants": "~18.0.10",
+        "expo-crypto": "~15.0.8",
         "expo-font": "~14.0.9",
         "expo-glass-effect": "~0.1.7",
         "expo-haptics": "~15.0.7",
@@ -9054,18 +9055,6 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-auth-session/node_modules/expo-crypto": {
-      "version": "15.0.7",
-      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.7.tgz",
-      "integrity": "sha512-FUo41TwwGT2e5rA45PsjezI868Ch3M6wbCZsmqTWdF/hr+HyPcrp1L//dsh/hsrsyrQdpY/U96Lu71/wXePJeg==",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo-blur": {
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.7.tgz",
@@ -9089,6 +9078,17 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.8.tgz",
+      "integrity": "sha512-aF7A914TB66WIlTJvl5J6/itejfY78O7dq3ibvFltL9vnTALJ/7LYHvLT4fwmx9yUNS6ekLBtDGWivFWnj2Fcw==",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -38,6 +38,7 @@
     "expo": "~54.0.25",
     "expo-blur": "~15.0.7",
     "expo-constants": "~18.0.10",
+    "expo-crypto": "~15.0.8",
     "expo-font": "~14.0.9",
     "expo-glass-effect": "~0.1.7",
     "expo-haptics": "~15.0.7",


### PR DESCRIPTION
## Description
1. Introduced the **PlayMaker** feature inside the **Spaces** tab as an initial interactive board experience.   (commented out with a usage example)
2. Implemented a **dynamic board system** composed of `PlayMakerArea`, `PlayMakerBoard`,  `ClearShapesButton` & `ShapesTab `controls and `PlayerAssignmentPanel` **adapts automatically based on the provided board and button configs** (no hardcoded board UI).  
3. Built shape rendering + interactions (select/place, select arrow endpoints, etc.) using centralized Play Maker utilities and shared model types.  
4. Added a reusable **IconContainer** component that is fully **config driven** and can accept **any injected SVG icons**, making the toolbar easily extensible.  
5. Integrated a `PlayerAssignmentPanel` to support the PlayMaker player assignment flow.  This section displays all members part of team allowing players to be assigned to player icons on the board.
6.  Modified the `listTeamMembers` to return a list of `UserResponse` to display in the `PlayerAssignmentPanel`

Note: The component can be imported to any page where its styles can be adjusted via the commented out demo left in the `spaces` tab.

## How was this tested?
[x] Manual testing
[x] Unit testing (_Testing done with help of ai_)

**Screenshot**

1. Board screenshot with a player assigned to the selected player icon:
<img width="250" height="600" alt="image" src="https://github.com/user-attachments/assets/08a52301-1cf0-4f09-9111-faa90bf14ee6" />

2. Play Maker demo usage 

https://github.com/user-attachments/assets/ba49c3e2-8fc5-4f70-93a2-ec1805b48956

