### PR TITLE
chore: remove mock data from league overview

### DIFF
--- a/Frontend/app/(contexts)/my-leagues/[id]/index.tsx
+++ b/Frontend/app/(contexts)/my-leagues/[id]/index.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo, useState } from "react";
-import { ActivityIndicator, Pressable, Text, View } from "react-native";
-
+import React, { useState } from "react";
+import { ActivityIndicator, Text, View } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { ContentArea } from "@/components/ui/content-area";
 import { useLeagueHeader } from "@/hooks/use-team-league-header";
@@ -9,10 +8,8 @@ import {
   useLeagueDetailContext,
 } from "@/contexts/league-detail-context";
 import { styles } from "@/components/leagues/league.styles";
-import { GlassView } from "expo-glass-effect";
-
-type Tab = "Overview" | "Games" | "Teams";
-
+import SegmentedControl from "@react-native-segmented-control/segmented-control";
+import { createTeamStyles } from "@/components/teams/teams-styles";
 
 export default function MyLeagueScreen() {
   const params = useLocalSearchParams<{ id?: string | string[] }>();
@@ -30,64 +27,48 @@ function MyLeagueContent() {
   const { id, isLoading, handleFollow, title, isOwner } =
     useLeagueDetailContext();
 
-
-  const [tab, setTab] = useState<Tab>("Overview");
-  
-  const tabs = useMemo(() => ["Overview", "Games", "Teams"] as Tab[], []);
+  const [tab, setTab] = useState<"overview" | "games" | "teams">("overview");
 
   useLeagueHeader({ title, id, isOwner, onFollow: handleFollow });
 
   return (
-    <ContentArea
-      paddingBottom={60}
-      backgroundProps={{ preset: "red" }}
-    >
+    <ContentArea paddingBottom={60} backgroundProps={{ preset: "red" }}>
       {isLoading ? <ActivityIndicator size="small" color="#fff" /> : null}
+      <View style={createTeamStyles.container}>
+        {/* Tabs (same page, no routing) */}
+        <SegmentedControl
+          values={["Overview", "Games", "Teams"]}
+          selectedIndex={tab === "overview" ? 0 : tab === "games" ? 1 : 2}
+          onValueChange={(value) => {
+            if (value === "Overview") setTab("overview");
+            if (value === "Games") setTab("games");
+            if (value === "Teams") setTab("teams");
+          }}
+          style={{ marginBottom: 12, width: "90%" }}
+        />
 
-              {/* Tabs (same page, no routing) */}
-              <GlassView glassEffectStyle="regular" style={styles.tabsGlass}>
-                {tabs.map((t, idx) => {
-                  const active = t === tab;
-                  return (
-                    <Pressable
-                      key={t}
-                      onPress={() => setTab(t)}
-                      style={[
-                        styles.tabBtn,
-                        active && styles.tabBtnActive,
-                        idx === 1 && styles.tabMiddle,
-                      ]}
-                    >
-                      <Text style={[styles.tabText, active && styles.tabTextActive]}>
-                        {t}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </GlassView>
-      
-              {/* Content switches below */}
-              {tab === "Overview" && (
-                <View style={styles.emptyWrap}>
-                  <Text style={styles.emptyTitle}>Overview</Text>
-                  <Text style={styles.emptySubtitle}>Coming soon</Text>
-                </View>
-              )}
+        {/* Content switches below */}
+        {tab === "overview" && (
+          <View style={styles.emptyWrap}>
+            <Text style={styles.emptyTitle}>Overview</Text>
+            <Text style={styles.emptySubtitle}>Coming soon</Text>
+          </View>
+        )}
 
-              {tab === "Games" && (
-                <View style={styles.emptyWrap}>
-                  <Text style={styles.emptyTitle}>Games</Text>
-                  <Text style={styles.emptySubtitle}>Coming soon</Text>
-                </View>
-              )}
-      
-              {tab === "Teams" && (
-                <View style={styles.emptyWrap}>
-                  <Text style={styles.emptyTitle}>Teams</Text>
-                  <Text style={styles.emptySubtitle}>Coming soon</Text>
-                </View>
-              )}
-      
+        {tab === "games" && (
+          <View style={styles.emptyWrap}>
+            <Text style={styles.emptyTitle}>Games</Text>
+            <Text style={styles.emptySubtitle}>Coming soon</Text>
+          </View>
+        )}
+
+        {tab === "teams" && (
+          <View style={styles.emptyWrap}>
+            <Text style={styles.emptyTitle}>Teams</Text>
+            <Text style={styles.emptySubtitle}>Coming soon</Text>
+          </View>
+        )}
+      </View>
     </ContentArea>
   );
 }


### PR DESCRIPTION
## Description
- Removed placeholder/mock standings data from the league overview tab
- Replaced it with an empty state to match the Games and Teams tabs
