### PR TITLE
GO-275: Added endpoint to retrieve user’s teams within a league

### DIFF
--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueController.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueController.java
@@ -126,6 +126,11 @@ public class LeagueController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/{leagueId}/memberships/me")
+    public ResponseEntity<List<LeagueTeamResponse>> getMyLeagueMemberships(@PathVariable UUID leagueId) {
+        return ResponseEntity.ok(leagueService.getMyLeagueMemberships(leagueId));
+    }
+
     /* Test endpoint... TO DO: remove once Payment/ stripe is implemented */
     @PostMapping("/payment-event")
     public void producePaymentEvent(@RequestBody PaymentDTO paymentDTO) {


### PR DESCRIPTION
## Description
1. Added an endpoint that returns all teams belonging to a specific league **where the requesting user is a member of those teams**.

## How was it tested?
[X] Manual test (see screenshot)
[X] Unit test

**screenshot**
1. 200 Response 
<img width="1381" height="716" alt="image" src="https://github.com/user-attachments/assets/5b684aae-3749-4e4b-b770-b8c3e5136bee" />
