### PR TITLE
GO-295: Added create play endpoint

### DIFF
--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
@@ -98,4 +98,9 @@ public class TeamController {
     public ResponseEntity<TeamMemberResponse> demoteSelf(@PathVariable String userId, @PathVariable UUID teamId) {
         return ResponseEntity.ok(teamService.demoteSelfToPlayer(teamId, userId));
     }
+
+    @PostMapping("/{teamId}/play-maker")
+    public ResponseEntity<UUID> createPlay(@Valid @RequestBody List<PlayItemDTO> items) {
+        return ResponseEntity.status(201).body(teamService.createPlay(items));
+    }
 }

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/ArrowDTO.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/ArrowDTO.java
@@ -1,0 +1,21 @@
+package com.game.on.go_team_service.team.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record ArrowDTO(
+
+        @NotNull
+        UUID id,
+
+        @NotNull
+        @jakarta.validation.Valid
+        NodeRefDTO from,
+
+        @NotNull
+        @jakarta.validation.Valid
+        NodeRefDTO to
+
+) implements PlayItemDTO {
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/NodeRefDTO.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/NodeRefDTO.java
@@ -1,0 +1,9 @@
+package com.game.on.go_team_service.team.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record NodeRefDTO(
+        @NotNull UUID id
+) {}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/PersonNodeDTO.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/PersonNodeDTO.java
@@ -1,0 +1,24 @@
+package com.game.on.go_team_service.team.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record PersonNodeDTO(
+
+        @NotNull
+        UUID id,
+
+        @NotNull
+        Double x,
+
+        @NotNull
+        Double y,
+
+        @NotNull
+        Double size,
+
+        String associatedPlayerId
+
+) implements PlayItemDTO {}
+

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/PlayItemDTO.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/PlayItemDTO.java
@@ -1,0 +1,11 @@
+package com.game.on.go_team_service.team.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({@JsonSubTypes.Type(value = PersonNodeDTO.class, name = "person"),
+        @JsonSubTypes.Type(value = ArrowDTO.class, name = "arrow")})
+public sealed interface PlayItemDTO permits PersonNodeDTO, ArrowDTO {
+
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/Play.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/Play.java
@@ -1,0 +1,26 @@
+package com.game.on.go_team_service.team.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Entity
+@Builder
+@Table(name = "plays")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Play {
+
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @OneToMany(mappedBy = "play", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PlayNode> nodes;
+
+    @OneToMany(mappedBy = "play", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PlayEdge> edges;
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/PlayEdge.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/PlayEdge.java
@@ -1,0 +1,34 @@
+package com.game.on.go_team_service.team.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "play_edges")
+public class PlayEdge {
+
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "play_id", nullable = false)
+    private Play play;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_node_id", nullable = false)
+    private PlayNode from;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_node_id", nullable = false)
+    private PlayNode to;
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/PlayMakerShapeType.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/PlayMakerShapeType.java
@@ -1,0 +1,9 @@
+package com.game.on.go_team_service.team.model;
+
+public enum PlayMakerShapeType {
+
+    PERSON,
+
+    ARROW
+
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/PlayNode.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/PlayNode.java
@@ -1,0 +1,42 @@
+package com.game.on.go_team_service.team.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "play_nodes")
+public class PlayNode {
+
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "play_id", nullable = false)
+    private Play play;
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PlayMakerShapeType type;
+
+    @Column(name = "associated_player_id")
+    private String associatedPlayerId;
+
+    @Column(nullable = false)
+    private double x;
+
+    @Column(nullable = false)
+    private double y;
+
+    @Column(nullable = false)
+    private double size;
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayEdgeRepository.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayEdgeRepository.java
@@ -1,0 +1,17 @@
+package com.game.on.go_team_service.team.repository;
+
+import com.game.on.go_team_service.team.model.PlayEdge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.UUID;
+
+public interface PlayEdgeRepository extends JpaRepository<PlayEdge, UUID> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from PlayEdge e where e.play.id = :playId")
+    void deleteByPlayId(@Param("playId") UUID playId);
+}
+

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayNodeRepository.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayNodeRepository.java
@@ -1,0 +1,16 @@
+package com.game.on.go_team_service.team.repository;
+
+import com.game.on.go_team_service.team.model.PlayNode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.UUID;
+
+public interface PlayNodeRepository extends JpaRepository<PlayNode, UUID> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from PlayNode n where n.play.id = :playId")
+    void deleteByPlayId(@Param("playId") UUID playId);
+}

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayRepository.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayRepository.java
@@ -1,0 +1,9 @@
+package com.game.on.go_team_service.team.repository;
+
+import com.game.on.go_team_service.team.model.Play;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PlayRepository extends JpaRepository<Play, UUID> {
+}

--- a/Backend/go-team-service/src/main/resources/db/migration/V4__Insert_play_maker.sql
+++ b/Backend/go-team-service/src/main/resources/db/migration/V4__Insert_play_maker.sql
@@ -1,0 +1,60 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS plays (
+  id uuid PRIMARY KEY,
+  name text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS play_nodes (
+  id uuid PRIMARY KEY,
+  play_id uuid NOT NULL REFERENCES plays(id) ON DELETE CASCADE,
+
+  type text NOT NULL,
+  associated_player_id text,
+
+  x double precision NOT NULL,
+  y double precision NOT NULL,
+  size double precision NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_play_nodes_play_id_id
+  ON play_nodes (play_id, id);
+
+CREATE INDEX IF NOT EXISTS ix_play_nodes_play_id
+  ON play_nodes (play_id);
+
+CREATE INDEX IF NOT EXISTS ix_play_nodes_associated_player_id
+  ON play_nodes (associated_player_id);
+
+CREATE TABLE IF NOT EXISTS play_edges (
+  id uuid PRIMARY KEY,
+  play_id uuid NOT NULL REFERENCES plays(id) ON DELETE CASCADE,
+
+  from_node_id uuid NOT NULL,
+  to_node_id uuid NOT NULL,
+
+  CONSTRAINT chk_play_edges_from_to_not_same
+    CHECK (from_node_id <> to_node_id),
+
+  CONSTRAINT fk_play_edges_from_node
+    FOREIGN KEY (play_id, from_node_id)
+    REFERENCES play_nodes (play_id, id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT fk_play_edges_to_node
+    FOREIGN KEY (play_id, to_node_id)
+    REFERENCES play_nodes (play_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS ix_play_edges_play_id
+  ON play_edges (play_id);
+
+CREATE INDEX IF NOT EXISTS ix_play_edges_from_node_id
+  ON play_edges (from_node_id);
+
+CREATE INDEX IF NOT EXISTS ix_play_edges_to_node_id
+  ON play_edges (to_node_id);
+
+COMMIT;


### PR DESCRIPTION
## Description
1. Added create play endpoint in the `go-team-service` allowing to persist plays received by the `PlayMaker` component.

## How was this tested?
[x] Manuel test **see screenshots**
[x] Unit tests

**Screenshots**
1. 201 - Created code :
<img width="1357" height="530" alt="image" src="https://github.com/user-attachments/assets/f01be289-25f4-4bf5-b1a2-8c69b5067539" />

2.  Plays table:
<img width="699" height="257" alt="image" src="https://github.com/user-attachments/assets/9383d61d-ee4c-4de1-b434-913786b53686" />

3. Play_nodes table:
<img width="1396" height="353" alt="image" src="https://github.com/user-attachments/assets/7dce88d1-f39b-4b21-8ed2-4ffa76dcf9fa" />

4. Play_edges table: 
<img width="1273" height="279" alt="image" src="https://github.com/user-attachments/assets/4bb89601-0d2f-456c-b9f4-3fc1178d2e51" />

