### PR TITLE
league-post

### DIFF
--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueTeamRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueTeamRepository.java
@@ -20,4 +20,6 @@ public interface LeagueTeamRepository extends JpaRepository<LeagueTeam, UUID> {
 
     @Query("select distinct lt.league.id from LeagueTeam lt where lt.teamId in :teamIds")
     List<UUID> findLeagueIdsByTeamIdIn(@Param("teamIds") Collection<UUID> teamIds);
+
+    boolean existsByLeague_IdAndTeamIdIn(UUID leagueId, Collection<UUID> teamIds);
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/controller/LeaguePostController.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/controller/LeaguePostController.java
@@ -1,0 +1,63 @@
+package com.game.on.go_league_service.league_post.controller;
+
+import com.game.on.go_league_service.league_post.dto.*;
+import com.game.on.go_league_service.league_post.service.LeaguePostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/leagues/{leagueId}/posts")
+@RequiredArgsConstructor
+public class LeaguePostController {
+
+    private final LeaguePostService service;
+
+    @PostMapping
+    public ResponseEntity<LeaguePostResponse> create(
+            @PathVariable UUID leagueId,
+            @Valid @RequestBody LeaguePostCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(leagueId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<LeaguePostListResponse> list(
+            @PathVariable UUID leagueId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(service.list(leagueId, page, size));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<LeaguePostResponse> get(
+            @PathVariable UUID leagueId,
+            @PathVariable UUID postId
+    ) {
+        LeaguePostResponse response = service.get(leagueId, postId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<LeaguePostResponse> update(
+            @PathVariable UUID leagueId,
+            @PathVariable UUID postId,
+            @Valid @RequestBody LeaguePostUpdateRequest request
+    ) {
+        return ResponseEntity.ok(service.update(leagueId, postId, request));
+    }
+
+    @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @PathVariable UUID leagueId,
+            @PathVariable UUID postId
+    ) {
+        service.delete(leagueId, postId);
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostCreateRequest.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostCreateRequest.java
@@ -1,0 +1,19 @@
+package com.game.on.go_league_service.league_post.dto;
+
+import com.game.on.go_league_service.league_post.model.LeaguePostScope;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+
+public record LeaguePostCreateRequest(
+        @Size(min = 1, max = 200, message = "title must be at most 120 characters")
+        String title,
+
+        @NotBlank(message = "body is required")
+        @Size(min = 1, max = 1000, message = "body must be at most 2000 characters")
+        String body,
+
+        @NotNull
+        LeaguePostScope scope
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostListResponse.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostListResponse.java
@@ -1,0 +1,11 @@
+package com.game.on.go_league_service.league_post.dto;
+
+import java.util.List;
+
+public record LeaguePostListResponse(
+        List<LeaguePostResponse> items,
+        long total,
+        int page,
+        int size,
+        boolean hasNext
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostResponse.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostResponse.java
@@ -1,0 +1,16 @@
+package com.game.on.go_league_service.league_post.dto;
+
+import com.game.on.go_league_service.league_post.model.LeaguePostScope;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record LeaguePostResponse(
+        UUID id,
+        UUID leagueId,
+        String authorUserId,
+        String title,
+        String body,
+        LeaguePostScope scope,
+        OffsetDateTime createdAt
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostUpdateRequest.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/dto/LeaguePostUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.game.on.go_league_service.league_post.dto;
+
+import com.game.on.go_league_service.league_post.model.LeaguePostScope;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LeaguePostUpdateRequest(
+        @Size(min = 1, max = 200, message = "title must be at most 200 characters")
+        String title,
+
+        @NotBlank
+        @Size(min = 1, max = 1000, message = "body must be at most 1000 characters")
+        String body,
+
+        @NotNull
+        LeaguePostScope scope
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/mapper/LeaguePostMapper.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/mapper/LeaguePostMapper.java
@@ -1,0 +1,40 @@
+package com.game.on.go_league_service.league_post.mapper;
+
+import com.game.on.go_league_service.league_post.dto.LeaguePostCreateRequest;
+import com.game.on.go_league_service.league_post.dto.LeaguePostResponse;
+import com.game.on.go_league_service.league_post.model.LeaguePost;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class LeaguePostMapper {
+
+    public LeaguePost toLeaguePost(UUID leagueId, LeaguePostCreateRequest request, String authorUserId) {
+        return LeaguePost.builder()
+                .leagueId(leagueId)
+                .authorUserId(authorUserId)
+                .title(trimToNull(request.title()))
+                .body(request.body().trim())
+                .scope(request.scope())
+                .build();
+    }
+
+    public LeaguePostResponse toResponse(LeaguePost post) {
+        return new LeaguePostResponse(
+                post.getId(),
+                post.getLeagueId(),
+                post.getAuthorUserId(),
+                post.getTitle(),
+                post.getBody(),
+                post.getScope(),
+                post.getCreatedAt()
+        );
+    }
+
+    private String trimToNull(String s) {
+        if (s == null) return null;
+        var t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/model/LeaguePost.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/model/LeaguePost.java
@@ -1,0 +1,51 @@
+package com.game.on.go_league_service.league_post.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "league_posts")
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class LeaguePost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @EqualsAndHashCode.Include
+    private UUID id;
+
+    @JoinColumn(name = "league_id", nullable = false)
+    private UUID leagueId;
+
+    @Column(name = "author_user_id", nullable = false, length = 255)
+    private String authorUserId;
+
+    @Column(name = "title", length = 200)
+    private String title;
+
+    @Column(name = "body", nullable = false, length = 1000)
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "scope", nullable = false, length = 30)
+    private LeaguePostScope scope;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/model/LeaguePostScope.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/model/LeaguePostScope.java
@@ -1,0 +1,26 @@
+package com.game.on.go_league_service.league_post.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum LeaguePostScope {
+    MEMBERS("Members"),
+    EVERYONE("Everyone");
+
+    private final String apiValue;
+
+    LeaguePostScope(String apiValue) { this.apiValue = apiValue; }
+
+    @JsonValue
+    public String getApiValue() { return apiValue; }
+
+    @JsonCreator
+    public static LeaguePostScope from(String value) {
+        if (value == null) return null;
+        String v = value.trim();
+        for (LeaguePostScope s : values()) {
+            if (s.apiValue.equalsIgnoreCase(v) || s.name().equalsIgnoreCase(v)) return s;
+        }
+        throw new IllegalArgumentException("Invalid scope: " + value + ". Allowed: Members, Everyone");
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/repository/LeaguePostRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/repository/LeaguePostRepository.java
@@ -1,0 +1,20 @@
+package com.game.on.go_league_service.league_post.repository;
+
+import com.game.on.go_league_service.league_post.model.LeaguePost;
+import com.game.on.go_league_service.league_post.model.LeaguePostScope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LeaguePostRepository extends JpaRepository<LeaguePost, UUID> {
+
+    Page<LeaguePost> findByLeagueId(UUID leagueId, Pageable pageable);
+
+    Page<LeaguePost> findByLeagueIdAndScope(UUID leagueId, LeaguePostScope scope, Pageable pageable);
+
+    Optional<LeaguePost> findByIdAndLeagueId(UUID postId, UUID leagueId);
+
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/service/LeaguePostService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/service/LeaguePostService.java
@@ -1,0 +1,136 @@
+package com.game.on.go_league_service.league_post.service;
+
+import com.game.on.go_league_service.config.CurrentUserProvider;
+import com.game.on.go_league_service.exception.ForbiddenException;
+import com.game.on.go_league_service.exception.NotFoundException;
+import com.game.on.go_league_service.league.model.League;
+import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
+import com.game.on.go_league_service.league.service.LeagueService;
+import com.game.on.go_league_service.league_post.dto.*;
+import com.game.on.go_league_service.league_post.mapper.LeaguePostMapper;
+import com.game.on.go_league_service.league_post.model.LeaguePost;
+import com.game.on.go_league_service.league_post.model.LeaguePostScope;
+import com.game.on.go_league_service.league_post.repository.LeaguePostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LeaguePostService {
+
+    private final LeaguePostRepository postRepository;
+    private final LeagueService leagueService;
+    private final LeagueTeamRepository leagueTeamRepository;
+    private final CurrentUserProvider userProvider;
+    private final LeaguePostMapper mapper;
+
+    @Transactional
+    public LeaguePostResponse create(UUID leagueId, LeaguePostCreateRequest request) {
+        String userId = userProvider.clerkUserId();
+        League league = leagueService.requireActiveLeague(leagueId);
+
+        ensureOwner(league, userId);
+
+        LeaguePost post = mapper.toLeaguePost(leagueId, request, userId);
+
+        LeaguePost saved = postRepository.save(post);
+        return mapper.toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public LeaguePostListResponse list(UUID leagueId, int page, int size) {
+        String userId = userProvider.clerkUserId();
+        League league = leagueService.requireActiveLeague(leagueId);
+
+        int safePage = Math.max(page, 0);
+        int effectiveSize = (size <= 0) ? 20 : Math.min(size, 50);
+
+        var pageable = PageRequest.of(safePage, effectiveSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        boolean canViewMembers = canViewMembersScope(league, userId);
+
+        var pageResult = canViewMembers
+                ? postRepository.findByLeagueId(leagueId, pageable)
+                : postRepository.findByLeagueIdAndScope(leagueId, LeaguePostScope.EVERYONE, pageable);
+
+        var items = pageResult.stream().map(mapper::toResponse).toList();
+
+        return new LeaguePostListResponse(
+                items,
+                pageResult.getTotalElements(),
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.hasNext()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public LeaguePostResponse get(UUID leagueId, UUID postId) {
+        String userId = userProvider.clerkUserId();
+        League league = leagueService.requireActiveLeague(leagueId);
+
+        LeaguePost post = requireActiveLeaguePost(leagueId, postId);
+
+        if (post.getScope() == LeaguePostScope.MEMBERS && !canViewMembersScope(league, userId)) {
+            throw new ForbiddenException("You are not allowed to view this post");
+        }
+
+        return mapper.toResponse(post);
+    }
+
+    @Transactional
+    public LeaguePostResponse update(UUID leagueId, UUID postId, LeaguePostUpdateRequest request) {
+        String userId = userProvider.clerkUserId();
+        League league = leagueService.requireActiveLeague(leagueId);
+
+        ensureOwner(league, userId);
+
+        LeaguePost post = requireActiveLeaguePost(leagueId, postId);
+
+        post.setTitle(request.title() == null ? null : request.title().trim());
+        post.setBody(request.body().trim());
+        post.setScope(request.scope());
+
+        LeaguePost saved = postRepository.save(post);
+        return mapper.toResponse(saved);
+    }
+
+    @Transactional
+    public void delete(UUID leagueId, UUID postId) {
+        String userId = userProvider.clerkUserId();
+        League league = leagueService.requireActiveLeague(leagueId);
+        ensureOwner(league, userId);
+
+        LeaguePost post = requireActiveLeaguePost(leagueId, postId);
+
+        postRepository.delete(post);
+    }
+
+    private void ensureOwner(League league, String userId) {
+        if (!league.getOwnerUserId().equals(userId)) {
+            throw new ForbiddenException("Only the owner can perform this action");
+        }
+    }
+
+    private boolean canViewMembersScope(League league, String userId) {
+        if (league.getOwnerUserId().equals(userId)) return true;
+
+        List<UUID> myTeamIds = leagueService.fetchTeamIdsForUser();
+        if (myTeamIds.isEmpty()) return false;
+
+        return leagueTeamRepository.existsByLeague_IdAndTeamIdIn(league.getId(), myTeamIds);
+    }
+
+    private LeaguePost requireActiveLeaguePost(UUID leagueId, UUID postId) {
+        return postRepository.findByIdAndLeagueId(postId, leagueId)
+                .orElseThrow(() -> new NotFoundException("Post not found"));
+    }
+}

--- a/Backend/go-league-service/src/main/resources/db/migration/V8__create_league_posts.sql
+++ b/Backend/go-league-service/src/main/resources/db/migration/V8__create_league_posts.sql
@@ -1,0 +1,16 @@
+CREATE TABLE league_posts (
+    id UUID PRIMARY KEY,
+    league_id UUID NOT NULL REFERENCES leagues(id),
+    author_user_id VARCHAR(255) NOT NULL,
+    title VARCHAR(200),
+    body VARCHAR(1000) NOT NULL,
+    scope VARCHAR(30) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_league_posts_league_id_created_at
+    ON league_posts (league_id, created_at DESC);
+
+CREATE INDEX idx_league_posts_league_id_scope_created_at
+    ON league_posts (league_id, scope, created_at DESC);

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueServiceTest.java
@@ -103,9 +103,10 @@ class LeagueServiceTest {
 
         LeagueCreateRequest request = new LeagueCreateRequest(
                 "Downtown League",
-                "basketball",
-                "Quebec",
+                "Soccer",
+                "Winter 2025",
                 "Montreal",
+                "Test description",
                 null,
                 null
         );
@@ -114,8 +115,10 @@ class LeagueServiceTest {
 
         assertThat(response.ownerUserId()).isEqualTo("user_123");
         assertThat(response.slug()).isEqualTo("downtown-league");
+
         assertThat(response.level()).isEqualTo(LeagueLevel.COMPETITIVE);
         assertThat(response.privacy()).isEqualTo(LeaguePrivacy.PUBLIC);
+
         assertThat(response.seasonCount()).isZero();
 
         verify(metricsPublisher).leagueCreated();
@@ -127,8 +130,15 @@ class LeagueServiceTest {
         when(slugGenerator.generateUniqueSlug(any()))
                 .thenThrow(new BadRequestException("Unable to generate league slug"));
 
-        LeagueCreateRequest request =
-                new LeagueCreateRequest("!!!", "soccer", null, null, null, null);
+        LeagueCreateRequest request = new LeagueCreateRequest(
+                "!!!",
+                "soccer",
+                "Winter 2025",
+                "Montreal",
+                "desc",
+                LeagueLevel.RECREATIONAL,
+                LeaguePrivacy.PUBLIC
+        );
 
         assertThatThrownBy(() -> leagueService.createLeague(request))
                 .isInstanceOf(BadRequestException.class);
@@ -167,9 +177,11 @@ class LeagueServiceTest {
                 "volleyball",
                 "Ontario",
                 "Toronto",
+                "Updated description",
                 LeagueLevel.RECREATIONAL,
                 LeaguePrivacy.PRIVATE
         );
+
 
         var response = leagueService.updateLeague(leagueId, update);
 
@@ -206,7 +218,8 @@ class LeagueServiceTest {
         assertThatThrownBy(() ->
                 leagueService.updateLeague(
                         leagueId,
-                        new LeagueUpdateRequest(null, null, null, null, null, null)
+                        new LeagueUpdateRequest(null, null, null, null, null, null, null)
+
                 )
         ).isInstanceOf(BadRequestException.class);
 
@@ -236,7 +249,8 @@ class LeagueServiceTest {
         assertThatThrownBy(() ->
                 leagueService.updateLeague(
                         leagueId,
-                        new LeagueUpdateRequest("New", null, null, null, null, null)
+                        new LeagueUpdateRequest("New", null, null, null, null, null, null)
+
                 )
         ).isInstanceOf(ForbiddenException.class);
 

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league_post/service/LeaguePostServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league_post/service/LeaguePostServiceTest.java
@@ -1,0 +1,276 @@
+package com.game.on.go_league_service.league_post.service;
+
+import com.game.on.go_league_service.config.CurrentUserProvider;
+import com.game.on.go_league_service.exception.ForbiddenException;
+import com.game.on.go_league_service.exception.NotFoundException;
+import com.game.on.go_league_service.league.model.League;
+import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
+import com.game.on.go_league_service.league.service.LeagueService;
+import com.game.on.go_league_service.league_post.dto.LeaguePostCreateRequest;
+import com.game.on.go_league_service.league_post.dto.LeaguePostResponse;
+import com.game.on.go_league_service.league_post.dto.LeaguePostUpdateRequest;
+import com.game.on.go_league_service.league_post.mapper.LeaguePostMapper;
+import com.game.on.go_league_service.league_post.model.LeaguePost;
+import com.game.on.go_league_service.league_post.model.LeaguePostScope;
+import com.game.on.go_league_service.league_post.repository.LeaguePostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LeaguePostServiceTest {
+
+    @Mock private LeaguePostRepository postRepository;
+    @Mock private LeagueService leagueService;
+    @Mock private LeagueTeamRepository leagueTeamRepository;
+    @Mock private CurrentUserProvider userProvider;
+    @Mock private LeaguePostMapper mapper;
+
+    @InjectMocks private LeaguePostService service;
+
+    private UUID leagueId;
+    private UUID postId;
+    private String ownerUserId;
+    private String memberUserId;
+    private String outsiderUserId;
+
+    private League league;
+
+    @BeforeEach
+    void setUp() {
+        leagueId = UUID.randomUUID();
+        postId = UUID.randomUUID();
+        ownerUserId = "owner_user";
+        memberUserId = "member_user";
+        outsiderUserId = "outsider_user";
+
+        league = League.builder()
+                .id(leagueId)
+                .ownerUserId(ownerUserId)
+                .build();
+    }
+
+    @Test
+    void owner_can_create_post() {
+        when(userProvider.clerkUserId()).thenReturn(ownerUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        LeaguePostCreateRequest req = new LeaguePostCreateRequest(
+                "Title",
+                "Body",
+                LeaguePostScope.EVERYONE
+        );
+
+        LeaguePost toSave = LeaguePost.builder()
+                .leagueId(leagueId)
+                .authorUserId(ownerUserId)
+                .title("Title")
+                .body("Body")
+                .scope(LeaguePostScope.EVERYONE)
+                .build();
+
+        LeaguePost saved = LeaguePost.builder()
+                .id(UUID.randomUUID())
+                .leagueId(leagueId)
+                .authorUserId(ownerUserId)
+                .title("Title")
+                .body("Body")
+                .scope(LeaguePostScope.EVERYONE)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        LeaguePostResponse resp = new LeaguePostResponse(
+                saved.getId(),
+                leagueId,
+                ownerUserId,
+                "Title",
+                "Body",
+                LeaguePostScope.EVERYONE,
+                saved.getCreatedAt()
+        );
+
+        when(mapper.toLeaguePost(leagueId, req, ownerUserId)).thenReturn(toSave);
+        when(postRepository.save(toSave)).thenReturn(saved);
+        when(mapper.toResponse(saved)).thenReturn(resp);
+
+        LeaguePostResponse result = service.create(leagueId, req);
+
+        assertEquals(resp.id(), result.id());
+        assertEquals(ownerUserId, result.authorUserId());
+        verify(postRepository).save(toSave);
+    }
+
+    @Test
+    void non_owner_cannot_create_post() {
+        when(userProvider.clerkUserId()).thenReturn("not_owner");
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        LeaguePostCreateRequest req = new LeaguePostCreateRequest(
+                "Title",
+                "Body",
+                LeaguePostScope.EVERYONE
+        );
+
+        assertThrows(ForbiddenException.class, () -> service.create(leagueId, req));
+        verify(postRepository, never()).save(any());
+    }
+
+    @Test
+    void owner_list_returns_all_posts() {
+        when(userProvider.clerkUserId()).thenReturn(ownerUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        LeaguePost p1 = LeaguePost.builder()
+                .id(UUID.randomUUID())
+                .leagueId(leagueId)
+                .authorUserId(ownerUserId)
+                .title("T1")
+                .body("B1")
+                .scope(LeaguePostScope.MEMBERS)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        Page<LeaguePost> page = new PageImpl<>(List.of(p1), PageRequest.of(0, 20), 1);
+
+        when(postRepository.findByLeagueId(eq(leagueId), any(Pageable.class))).thenReturn(page);
+        when(mapper.toResponse(p1)).thenReturn(new LeaguePostResponse(
+                p1.getId(),
+                leagueId,
+                p1.getAuthorUserId(),
+                p1.getTitle(),
+                p1.getBody(),
+                p1.getScope(),
+                p1.getCreatedAt()
+        ));
+
+        var result = service.list(leagueId, 0, 20);
+
+        assertEquals(1, result.items().size());
+        verify(postRepository).findByLeagueId(eq(leagueId), any(Pageable.class));
+        verify(postRepository, never()).findByLeagueIdAndScope(any(), any(), any());
+    }
+
+    @Test
+    void outsider_list_returns_only_everyone_posts() {
+        when(userProvider.clerkUserId()).thenReturn(outsiderUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        when(leagueService.fetchTeamIdsForUser()).thenReturn(List.of());
+
+        Page<LeaguePost> page = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
+        when(postRepository.findByLeagueIdAndScope(eq(leagueId), eq(LeaguePostScope.EVERYONE), any(Pageable.class)))
+                .thenReturn(page);
+
+        var result = service.list(leagueId, 0, 20);
+
+        assertEquals(0, result.items().size());
+        verify(postRepository).findByLeagueIdAndScope(eq(leagueId), eq(LeaguePostScope.EVERYONE), any(Pageable.class));
+        verify(postRepository, never()).findByLeagueId(any(), any());
+    }
+
+    @Test
+    void member_can_read_members_scope_post() {
+        when(userProvider.clerkUserId()).thenReturn(memberUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        List<UUID> myTeams = List.of(UUID.randomUUID());
+        when(leagueService.fetchTeamIdsForUser()).thenReturn(myTeams);
+        when(leagueTeamRepository.existsByLeague_IdAndTeamIdIn(leagueId, myTeams)).thenReturn(true);
+
+        LeaguePost post = LeaguePost.builder()
+                .id(postId)
+                .leagueId(leagueId)
+                .authorUserId(ownerUserId)
+                .title("Members")
+                .body("Only members")
+                .scope(LeaguePostScope.MEMBERS)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        when(postRepository.findByIdAndLeagueId(postId, leagueId)).thenReturn(Optional.of(post));
+
+        when(mapper.toResponse(post)).thenReturn(new LeaguePostResponse(
+                postId,
+                leagueId,
+                ownerUserId,
+                "Members",
+                "Only members",
+                LeaguePostScope.MEMBERS,
+                post.getCreatedAt()
+        ));
+
+        LeaguePostResponse result = service.get(leagueId, postId);
+        assertEquals(postId, result.id());
+
+        verify(postRepository).findByIdAndLeagueId(postId, leagueId);
+    }
+
+    @Test
+    void outsider_cannot_read_members_scope_post() {
+        when(userProvider.clerkUserId()).thenReturn(outsiderUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        when(leagueService.fetchTeamIdsForUser()).thenReturn(List.of());
+
+        LeaguePost post = LeaguePost.builder()
+                .id(postId)
+                .leagueId(leagueId)
+                .authorUserId(ownerUserId)
+                .title("Members")
+                .body("Only members")
+                .scope(LeaguePostScope.MEMBERS)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        when(postRepository.findByIdAndLeagueId(postId, leagueId)).thenReturn(Optional.of(post));
+
+        assertThrows(ForbiddenException.class, () -> service.get(leagueId, postId));
+        verify(postRepository).findByIdAndLeagueId(postId, leagueId);
+    }
+
+    @Test
+    void non_owner_cannot_update_or_delete() {
+        when(userProvider.clerkUserId()).thenReturn(memberUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        LeaguePostUpdateRequest update = new LeaguePostUpdateRequest(
+                "New title",
+                "New body",
+                LeaguePostScope.EVERYONE
+        );
+
+        assertThrows(ForbiddenException.class, () -> service.update(leagueId, postId, update));
+        assertThrows(ForbiddenException.class, () -> service.delete(leagueId, postId));
+
+        verify(postRepository, never()).save(any());
+        verify(postRepository, never()).delete(any());
+    }
+
+    @Test
+    void not_found_when_post_does_not_exist() {
+        when(userProvider.clerkUserId()).thenReturn(ownerUserId);
+        when(leagueService.requireActiveLeague(leagueId)).thenReturn(league);
+
+        when(postRepository.findByIdAndLeagueId(postId, leagueId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.get(leagueId, postId));
+    }
+}


### PR DESCRIPTION
Developed with the assistance of ChatGPT

## Description
Implements backend support for **League Announcement Posts** (Issue #317).

League owners can create, update, and delete announcement posts that appear on the League Board.  
Visibility is controlled via scope (`MEMBERS` or `EVERYONE`) with proper RBAC and membership checks enforced.

---

## What’s Included

###  Database
- Added Flyway migration: `V8__create_league_posts.sql`
- Created `league_posts` table with:
  - `id`
  - `league_id`
  - `author_user_id`
  - `title`
  - `body`
  - `scope` (`MEMBERS`, `EVERYONE`)
  - `created_at`
  - `updated_at`
- Added indexes:
  - `(league_id, created_at)`
  - `(league_id, scope, created_at)`

---

### Authorization Rules

**Create / Update / Delete**
- Allowed: **League Owner only**
- Others → `403 Forbidden`

**Read (List / Get)**
- `EVERYONE` → visible to all users
- `MEMBERS` → visible only to:
  - League owner
  - Users belonging to a team in the league
- Non-member accessing private post → `403 Forbidden`

---

### API Endpoints
POST /leagues/{leagueId}/posts
GET /leagues/{leagueId}/posts
GET /leagues/{leagueId}/posts/{postId}
PUT /leagues/{leagueId}/posts/{postId}
DELETE /leagues/{leagueId}/posts/{postId}


Supports:
- Pagination (`page`, `size`)
- Sorting (default by `createdAt DESC`)

---

### Tests Added
- Owner can create post
- Non-owner cannot create
- Owner can list all posts
- Outsider sees only `EVERYONE` posts
- Member can read `MEMBERS` post
- Outsider blocked from `MEMBERS` post
- Non-owner cannot update/delete
- NotFound when post does not exist

---

###  Validation
- `body` required
- `title` optional
- Enum scope supports:
  - `"Members"` / `"Everyone"` (case-insensitive)
  - Stored internally as enum

---

##  Related Issue
Closes #317

---

## Notes
- Hard delete implemented
- Migration is backward compatible
- All tests passing locally

### Screenshots
`POST /leagues/{leagueId}/posts`
<img width="1084" height="587" alt="create" src="https://github.com/user-attachments/assets/cbb4ba47-2bee-4d13-b7c8-cd627d7a86a1" />

`GET /leagues/{leagueId}/posts`
<img width="1075" height="785" alt="list" src="https://github.com/user-attachments/assets/4bfd082b-88e2-4084-b2b7-0b8bd0cb4b0b" />

`GET /leagues/{leagueId}/posts/{postId}`
<img width="1079" height="584" alt="get" src="https://github.com/user-attachments/assets/1784e396-7c0e-4aab-b00b-da5039490401" />

`DELETE /leagues/{leagueId}/posts/{postId}`
<img width="1073" height="445" alt="delete" src="https://github.com/user-attachments/assets/fd91843d-4a57-464b-8bdc-d619edc2e7ae" />
