### PR TITLE
GO-330: Added GET endpoint for plays

### DIFF
--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
@@ -108,4 +108,9 @@ public class TeamController {
     public ResponseEntity<UUID> createPlay(@Valid @RequestBody List<PlayItemDTO> items) {
         return ResponseEntity.status(201).body(teamService.createPlay(items));
     }
+
+    @GetMapping("/{teamId}/plays/{playId}")
+    public List<PlayItemDTO> getPlay(@PathVariable UUID teamId, @PathVariable UUID playId) {
+        return teamService.getPlayItems(teamId, playId);
+    }
 }

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/Play.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/Play.java
@@ -18,6 +18,10 @@ public class Play {
     @Column(nullable = false)
     private UUID id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
     @OneToMany(mappedBy = "play", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlayNode> nodes;
 

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayEdgeRepository.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayEdgeRepository.java
@@ -6,9 +6,19 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface PlayEdgeRepository extends JpaRepository<PlayEdge, UUID> {
+
+    @Query("""
+        select e
+        from PlayEdge e
+        join fetch e.from
+        join fetch e.to
+        where e.play.id = :playId
+    """)
+    List<PlayEdge> findByPlayIdWithNodes(@Param("playId") UUID playId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from PlayEdge e where e.play.id = :playId")

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayNodeRepository.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayNodeRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface PlayNodeRepository extends JpaRepository<PlayNode, UUID> {
+
+    List<PlayNode> findByPlayId(UUID playId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from PlayNode n where n.play.id = :playId")

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayRepository.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/repository/PlayRepository.java
@@ -6,4 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface PlayRepository extends JpaRepository<Play, UUID> {
+
+    boolean existsByIdAndTeam_Id(UUID playId, UUID teamId);
+
 }

--- a/Backend/go-team-service/src/main/resources/db/migration/V9__add_team_fk_to_plays.sql
+++ b/Backend/go-team-service/src/main/resources/db/migration/V9__add_team_fk_to_plays.sql
@@ -1,0 +1,10 @@
+ALTER TABLE plays
+ADD COLUMN team_id UUID;
+
+ALTER TABLE plays
+ADD CONSTRAINT fk_plays_team
+FOREIGN KEY (team_id)
+REFERENCES teams(id)
+ON DELETE CASCADE;
+
+CREATE INDEX idx_plays_team_id ON plays(team_id);


### PR DESCRIPTION
## Description
1. Added a GET endpoint to retrieve Plays for the `PlayMaker` component.
2. Added a flyway script altering the Play schema. This allows plays to be linked to a team id which in turns allows to verify for active status, request membership and link plays to teams.

## How was this tested?
[X] Manual tests (see screenshots)
[X] Unit tests

**Screenshots**
1. 202 response for a GET play request:
<img width="1350" height="814" alt="image" src="https://github.com/user-attachments/assets/96065b46-2065-4a97-875b-d752897f805a" />
