### PR TITLE
GH-344: Addressed defect for Team service enforce roster limit

### DIFF
--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamCreateRequest.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamCreateRequest.java
@@ -23,8 +23,9 @@ public record TeamCreateRequest(
         String location,
         List<@Size(max = 100, message = "allowedRegions entries cannot exceed 100 characters") String> allowedRegions,
 
-//        @Positive(message = "maxRoster must be greater than 0")
-//        Integer maxRoster,
+        @Positive(message = "maxRoster must be greater than 0")
+        Integer maxRoster,
+
         TeamPrivacy privacy
 ) {
 }

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamDetailResponse.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamDetailResponse.java
@@ -17,7 +17,7 @@ public record TeamDetailResponse(
         String logoUrl,
         String location,
         List<String> allowedRegions,
-//        Integer maxRoster,
+        Integer maxRoster,
         TeamPrivacy privacy,
         boolean archived,
         OffsetDateTime createdAt,

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamSummaryResponse.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamSummaryResponse.java
@@ -13,7 +13,7 @@ public record TeamSummaryResponse(
         String slug,
         String logoUrl,
         TeamPrivacy privacy,
-//        Integer maxRoster,
+        Integer maxRoster,
         boolean archived,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamUpdateRequest.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/dto/TeamUpdateRequest.java
@@ -19,8 +19,10 @@ public record TeamUpdateRequest(
         @Size(max = 255, message = "location cannot exceed 255 characters")
         String location,
         List<@Size(max = 100, message = "allowedRegions entries cannot exceed 100 characters") String> allowedRegions,
-//        @Positive(message = "maxRoster must be greater than 0")
-//        Integer maxRoster,
+
+        @Positive(message = "maxRoster must be greater than 0")
+        Integer maxRoster,
+
         TeamPrivacy privacy
 ) {
 }

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/mapper/TeamMapper.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/mapper/TeamMapper.java
@@ -25,6 +25,7 @@ public class TeamMapper {
 //                .leagueId(request.leagueId())
                 .scope(trimToNull(request.scope()))
                 .ownerUserId(ownerUserId)
+                .maxRoster(request.maxRoster())
                 .slug(slugGenerator.generateUniqueSlug(request.name()))
                 .logoUrl(trimToNull(request.logoUrl()))
                 .location(trimToNull(request.location()))
@@ -66,7 +67,7 @@ public class TeamMapper {
                 team.getLogoUrl(),
                 team.getLocation(),
                 new ArrayList<>(team.getAllowedRegions()),
-//                team.getMaxRoster(),
+                team.getMaxRoster(),
                 team.getPrivacy(),
                 team.isArchived(),
                 team.getCreatedAt(),
@@ -83,7 +84,7 @@ public class TeamMapper {
                 team.getSlug(),
                 team.getLogoUrl(),
                 team.getPrivacy(),
-//                team.getMaxRoster(),
+                team.getMaxRoster(),
                 team.isArchived(),
                 team.getCreatedAt(),
                 team.getUpdatedAt()

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/Team.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/model/Team.java
@@ -61,8 +61,8 @@ public class Team {
     @Column(name = "region", length = 100)
     private List<String> allowedRegions = new ArrayList<>();
 
-//    @Column(name = "max_roster")
-//    private Integer maxRoster;
+    @Column(name = "max_roster")
+    private Integer maxRoster;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/service/TeamService.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/service/TeamService.java
@@ -107,14 +107,14 @@ public class TeamService {
         if (request.allowedRegions() != null) {
             team.setAllowedRegions(normalizeRegions(request.allowedRegions()));
         }
-//        if (request.maxRoster() != null) {
-//            validateMaxRoster(request.maxRoster());
-//            var activeCount = teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
-//           if (request.maxRoster() < activeCount) {
-//                throw new BadRequestException("maxRoster cannot be less than current active members");
-//            }
-//            team.setMaxRoster(request.maxRoster());
-//        }
+        if (request.maxRoster() != null) {
+            validateMaxRoster(request.maxRoster());
+            var activeCount = teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
+           if (request.maxRoster() < activeCount) {
+                throw new BadRequestException("maxRoster cannot be less than current active members");
+            }
+            team.setMaxRoster(request.maxRoster());
+        }
         if (request.privacy() != null) {
             team.setPrivacy(request.privacy());
         }
@@ -283,7 +283,7 @@ public class TeamService {
             throw new ConflictException(format("User is already a member of the team %s", teamId));
         }
 
-//        enforceRosterLimit(team);
+        enforceRosterLimit(team);
 
         teamInviteRepository.findByTeamIdAndInviteeUserIdAndStatus(teamId, inviteeUserId, TeamInviteStatus.PENDING)
                 .ifPresent(invite -> {
@@ -357,7 +357,7 @@ public class TeamService {
         }
         log.info("Team member {} does not already exist in team {}", invitationId, userId);
 
-//        enforceRosterLimit(team);
+        enforceRosterLimit(team);
 
         TeamMember newMember = teamMapper.toTeamMember(team, userId, invite.getRole());
         teamMemberRepository.save(newMember);
@@ -558,15 +558,17 @@ public class TeamService {
         }
     }
 
-//    private void enforceRosterLimit(Team team) {
-//        if (team.getMaxRoster() == null) {
-//            return;
-//        }
-//        var activeCount = teamMemberRepository.countByTeamIdAndStatus(team.getId(), TeamMemberStatus.ACTIVE);
-//        if (activeCount >= team.getMaxRoster()) {
-//            throw new BadRequestException("Team roster is full");
-//        }
-//    }
+    private void enforceRosterLimit(Team team) {
+        if (team.getMaxRoster() == null) {
+            return;
+        }
+
+        var activeCount = teamMemberRepository.countByTeamIdAndStatus(team.getId(), TeamMemberStatus.ACTIVE);
+
+        if (activeCount >= team.getMaxRoster()) {
+            throw new BadRequestException("Team roster is full");
+        }
+    }
 
     private void enforceInviteOwnership(TeamInvite invite, String userId) {
         if (invite.getInviteeUserId() != null && !invite.getInviteeUserId().equals(userId)) {

--- a/Backend/go-team-service/src/test/java/com/game/on/go_team_service/TeamServiceTest.java
+++ b/Backend/go-team-service/src/test/java/com/game/on/go_team_service/TeamServiceTest.java
@@ -1,5 +1,6 @@
 package com.game.on.go_team_service;
 
+import com.game.on.common.dto.UserResponse;
 import com.game.on.go_team_service.client.UserClient;
 import com.game.on.go_team_service.config.CurrentUserProvider;
 import com.game.on.go_team_service.exception.BadRequestException;
@@ -294,6 +295,89 @@ class TeamServiceTest {
         assertEquals(TeamInviteStatus.ACCEPTED, invite.getStatus());
         assertNotNull(invite.getRespondedAt());
         assertEquals(callerUserId, invite.getInviteeUserId());
+    }
+
+    @Test
+    void createInvite_whenRosterIsFull_throwsBadRequest() {
+        UUID teamId = UUID.randomUUID();
+        TeamInviteCreateRequest request = new TeamInviteCreateRequest(
+                teamId,
+                "invitee_999",
+                TeamRole.PLAYER,
+                OffsetDateTime.now().plusDays(3)
+        );
+
+        Team team = new Team();
+        team.setId(teamId);
+        team.setMaxRoster(2);
+
+        TeamMember caller = new TeamMember();
+        caller.setRole(TeamRole.OWNER);
+        caller.setStatus(TeamMemberStatus.ACTIVE);
+
+        UserResponse invitee = new UserResponse(
+                "invitee_999",
+                "invitee@test.com",
+                "John",
+                "Doe"
+        );
+
+        when(teamRepository.findByIdAndDeletedAtIsNull(teamId))
+                .thenReturn(Optional.of(team));
+
+        when(teamMemberRepository.findByTeamIdAndUserId(teamId, callerUserId))
+                .thenReturn(Optional.of(caller));
+
+        when(userClient.getUserById("invitee_999")).thenReturn(invitee);
+
+        when(teamMemberRepository.existsByTeamIdAndUserId(teamId, "invitee_999"))
+                .thenReturn(false);
+
+        when(teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE))
+                .thenReturn(2L);
+
+        assertThrows(BadRequestException.class, () -> teamService.createInvite(request));
+
+        verify(teamInviteRepository, never()).save(any());
+        verify(metricsPublisher, never()).inviteSent();
+    }
+
+    @Test
+    void acceptInvite_whenRosterIsFull_throwsBadRequest() {
+        UUID inviteId = UUID.randomUUID();
+        TeamInvitationReply reply = new TeamInvitationReply(inviteId, true);
+
+        Team team = new Team();
+        team.setId(teamId);
+        team.setMaxRoster(3);
+
+        TeamInvite invite = new TeamInvite();
+        invite.setId(inviteId);
+        invite.setTeam(team);
+        invite.setStatus(TeamInviteStatus.PENDING);
+        invite.setInviteeUserId(callerUserId);
+        invite.setRole(TeamRole.PLAYER);
+        invite.setExpiresAt(OffsetDateTime.now().plusDays(1));
+
+        when(teamInviteRepository.findByIdAndStatus(inviteId, TeamInviteStatus.PENDING))
+                .thenReturn(Optional.of(invite));
+
+        when(teamRepository.findByIdAndDeletedAtIsNull(teamId))
+                .thenReturn(Optional.of(team));
+
+        when(teamMemberRepository.existsByTeamIdAndUserId(teamId, callerUserId))
+                .thenReturn(false);
+
+        when(teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE))
+                .thenReturn(3L);
+
+        assertThrows(BadRequestException.class, () -> teamService.acceptInvite(reply));
+
+        verify(teamMemberRepository, never()).save(any());
+        verify(teamInviteRepository, never()).save(argThat(savedInvite ->
+                savedInvite.getStatus() == TeamInviteStatus.ACCEPTED
+        ));
+        verify(metricsPublisher, never()).inviteAccepted();
     }
 
     @Test


### PR DESCRIPTION
## Description
1. Addressed  Enforce Roster limit defect

## How was this tested?
[X] Unit tests
[X] Manual test (see screenshots)

**screenshots**
1.  Max roster field exists in the Create Team Response:
<img width="1370" height="774" alt="image" src="https://github.com/user-attachments/assets/85ca860a-66ba-47f3-a5cf-a810e108151a" />

2. Inviting a player once the roster limit has been reached returns a 400 Error
<img width="1378" height="619" alt="image" src="https://github.com/user-attachments/assets/9109cb44-342a-4320-88c7-6fe6581e90f8" />
