### PR TITLE
GH-201: Created League standings endpoint

### DIFF
--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueController.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueController.java
@@ -3,6 +3,7 @@ package com.game.on.go_league_service.league.controller;
 import com.game.on.common.dto.PaymentDTO;
 import com.game.on.go_league_service.kafka.PaymentProducer;
 import com.game.on.go_league_service.league.dto.*;
+import com.game.on.go_league_service.league.model.StandingScore;
 import com.game.on.go_league_service.league.service.LeagueService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -135,5 +136,10 @@ public class LeagueController {
     @PostMapping("/payment-event")
     public void producePaymentEvent(@RequestBody PaymentDTO paymentDTO) {
         paymentProducer.sendEvent("go-payment", paymentDTO);
+    }
+
+    @GetMapping("/{leagueId}/standings")
+    public ResponseEntity<List<StandingScore>> getLeagueStandings(@PathVariable UUID leagueId) {
+        return ResponseEntity.ok(leagueService.getLeagueStandings(leagueId));
     }
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/SoccerStandingStrategy.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/SoccerStandingStrategy.java
@@ -1,0 +1,67 @@
+package com.game.on.go_league_service.league.model;
+
+import lombok.Data;
+
+import java.util.*;
+
+@Data
+public class SoccerStandingStrategy implements StandingStrategy {
+
+    @Override
+    public List<StandingScore> calculateStanding(List<UUID> teamIds, List<LeagueMatch> leagueMatches, Map<UUID, LeagueMatchScore> scoresByMatchId) {
+        Map<UUID, StandingScore> standings = new HashMap<>();
+
+        for (UUID teamId : teamIds) {
+            standings.put(teamId, new StandingScore(teamId));
+        }
+
+        for (LeagueMatch match : leagueMatches) {
+
+            LeagueMatchScore score = scoresByMatchId.get(match.getId());
+            if (score == null) {
+                continue;
+            }
+
+            UUID homeTeamId = match.getHomeTeamId();
+            UUID awayTeamId = match.getAwayTeamId();
+
+            StandingScore home = standings.get(homeTeamId);
+            StandingScore away = standings.get(awayTeamId);
+
+            if (home == null || away == null) {
+                continue;
+            }
+
+            int homeGoals = score.getHomeScore();
+            int awayGoals = score.getAwayScore();
+
+            home.setPlayed(home.getPlayed() + 1);
+            away.setPlayed(away.getPlayed() + 1);
+
+            home.setGoalsFor(home.getGoalsFor() + homeGoals);
+            home.setGoalsAgainst(home.getGoalsAgainst() + awayGoals);
+
+            away.setGoalsFor(away.getGoalsFor() + awayGoals);
+            away.setGoalsAgainst(away.getGoalsAgainst() + homeGoals);
+
+            if (homeGoals > awayGoals) {
+                home.setWins(home.getWins() + 1);
+                home.setPoints(home.getPoints() + 3);
+                away.setLosses(away.getLosses() + 1);
+            } else if (awayGoals > homeGoals) {
+                away.setWins(away.getWins() + 1);
+                away.setPoints(away.getPoints() + 3);
+                home.setLosses(home.getLosses() + 1);
+            } else {
+                home.setDraws(home.getDraws() + 1);
+                away.setDraws(away.getDraws() + 1);
+                home.setPoints(home.getPoints() + 1);
+                away.setPoints(away.getPoints() + 1);
+            }
+        }
+
+        return standings.values().stream()
+                .sorted(Comparator.comparingInt(StandingScore::getPoints).reversed())
+                .toList();
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/StandingScore.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/StandingScore.java
@@ -1,0 +1,29 @@
+package com.game.on.go_league_service.league.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StandingScore {
+    private UUID teamId;
+    private int played;
+    private int wins;
+    private int draws;
+    private int losses;
+    private int goalsFor;
+    private int goalsAgainst;
+    private int points;
+
+    public StandingScore(UUID teamId) {
+        this.teamId = teamId;
+    }
+
+    public int getGoalDifference() {
+        return Math.abs(goalsFor - goalsAgainst);
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/StandingStrategy.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/StandingStrategy.java
@@ -1,0 +1,9 @@
+package com.game.on.go_league_service.league.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface StandingStrategy {
+    List<StandingScore> calculateStanding(List<UUID> teamIds, List<LeagueMatch> matches, Map<UUID, LeagueMatchScore> scoresByMatchId);
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/StandingStrategyFactory.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/StandingStrategyFactory.java
@@ -1,0 +1,15 @@
+package com.game.on.go_league_service.league.model;
+
+public class StandingStrategyFactory {
+
+    public static StandingStrategy createStandingStrategy(String sportType) {
+        switch (sportType.toLowerCase()) {
+            case "soccer":
+                return new SoccerStandingStrategy();
+
+            default:
+                /* Keep default as soccer for now, need to discuss default behaviour next meeting */
+                return new SoccerStandingStrategy();
+        }
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueMatchScoreRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueMatchScoreRepository.java
@@ -3,9 +3,11 @@ package com.game.on.go_league_service.league.repository;
 import com.game.on.go_league_service.league.model.LeagueMatchScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface LeagueMatchScoreRepository extends JpaRepository<LeagueMatchScore, UUID> {
     Optional<LeagueMatchScore> findByMatch_Id(UUID matchId);
+    List<LeagueMatchScore> findByMatch_League_Id(UUID leagueId);
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueService.java
@@ -9,14 +9,10 @@ import com.game.on.go_league_service.exception.NotFoundException;
 import com.game.on.go_league_service.league.dto.*;
 import com.game.on.go_league_service.league.mapper.LeagueMapper;
 import com.game.on.go_league_service.league.metrics.LeagueMetricsPublisher;
-import com.game.on.go_league_service.league.model.League;
-import com.game.on.go_league_service.league.model.LeaguePrivacy;
-import com.game.on.go_league_service.league.model.LeagueSeason;
+import com.game.on.go_league_service.league.model.*;
 import com.game.on.go_league_service.league.mapper.LeagueTeamMapper;
-import com.game.on.go_league_service.league.repository.LeagueRepository;
-import com.game.on.go_league_service.league.repository.LeagueSeasonRepository;
+import com.game.on.go_league_service.league.repository.*;
 import com.game.on.go_league_service.league.repository.LeagueSeasonRepository.LeagueSeasonCountProjection;
-import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
 import com.game.on.go_league_service.league.util.SlugGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,10 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.game.on.go_league_service.league.service.LeagueSpecifications.*;
-import static java.lang.String.format;
 
 @Slf4j
 @Service
@@ -53,6 +49,8 @@ public class LeagueService {
     private final TeamClient teamClient;
     private final CurrentUserProvider userProvider;
     private final LeagueMetricsPublisher metricsPublisher;
+    private final LeagueMatchRepository leagueMatchRepository;
+    private final LeagueMatchScoreRepository leagueMatchScoreRepository;
 
     @Transactional
     public LeagueDetailResponse createLeague(LeagueCreateRequest request) {
@@ -313,6 +311,32 @@ public class LeagueService {
         log.info("league_season_archived leagueId={} seasonId={} byUser={}",
                 leagueId, seasonId, userId);
         // metricsPublisher.seasonArchived(); // optional
+    }
+
+    public List<StandingScore> getLeagueStandings(UUID leagueId) {
+        String userId = userProvider.clerkUserId();
+        League league = requireActiveLeague(leagueId);
+        ensureCanView(league, userId);
+
+        List<UUID> teamIds = leagueTeamRepository.findByLeague_IdOrderByCreatedAtDesc(leagueId)
+                .stream()
+                .map(LeagueTeam::getTeamId)
+                .distinct()
+                .toList();
+
+        List<LeagueMatch> matches = leagueMatchRepository.findByLeague_IdOrderByStartTimeDesc(leagueId);
+
+        Map<UUID, LeagueMatchScore> scoresByMatchId = leagueMatchScoreRepository
+                .findByMatch_League_Id(leagueId)
+                .stream()
+                .collect(Collectors.toMap(
+                        score -> score.getMatch().getId(),
+                        Function.identity()
+                ));
+
+        StandingStrategy strategy = StandingStrategyFactory.createStandingStrategy(league.getSport());
+
+        return strategy.calculateStanding(teamIds, matches, scoresByMatchId);
     }
 
     public List<LeagueTeamResponse> getMyLeagueMemberships(UUID leagueId) {

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueServiceTest.java
@@ -12,12 +12,8 @@ import com.game.on.go_league_service.league.dto.LeagueUpdateRequest;
 import com.game.on.go_league_service.league.mapper.LeagueMapper;
 import com.game.on.go_league_service.league.mapper.LeagueTeamMapper;
 import com.game.on.go_league_service.league.metrics.LeagueMetricsPublisher;
-import com.game.on.go_league_service.league.model.League;
-import com.game.on.go_league_service.league.model.LeagueLevel;
-import com.game.on.go_league_service.league.model.LeaguePrivacy;
-import com.game.on.go_league_service.league.repository.LeagueRepository;
-import com.game.on.go_league_service.league.repository.LeagueSeasonRepository;
-import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
+import com.game.on.go_league_service.league.model.*;
+import com.game.on.go_league_service.league.repository.*;
 import com.game.on.go_league_service.league.service.LeagueService;
 import com.game.on.go_league_service.league.util.SlugGenerator;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +67,12 @@ class LeagueServiceTest {
     @Mock
     private TeamClient client;
 
+    @Mock
+    private LeagueMatchRepository leagueMatchRepository;
+
+    @Mock
+    private LeagueMatchScoreRepository leagueMatchScoreRepository;
+
     private LeagueService leagueService;
 
     @BeforeEach
@@ -84,7 +86,9 @@ class LeagueServiceTest {
                 leagueTeamMapper,
                 client,
                 currentUserProvider,
-                metricsPublisher
+                metricsPublisher,
+                leagueMatchRepository,
+                leagueMatchScoreRepository
         );
     }
 
@@ -348,5 +352,298 @@ class LeagueServiceTest {
 
         verify(leagueTeamRepository, never()).findByLeague_IdAndTeamId(any(), any());
         verify(leagueTeamMapper, never()).toResponse(any());
+    }
+
+    @Test
+    void getLeagueStandings_calculatesSoccerStandingsCorrectly() {
+        UUID leagueId = UUID.randomUUID();
+        String userId = "user_1";
+
+        UUID teamA = UUID.randomUUID();
+        UUID teamB = UUID.randomUUID();
+        UUID teamC = UUID.randomUUID();
+
+        League league = League.builder()
+                .id(leagueId)
+                .name("Test League")
+                .sport("soccer")
+                .ownerUserId(userId)
+                .privacy(LeaguePrivacy.PUBLIC)
+                .level(LeagueLevel.COMPETITIVE)
+                .build();
+
+        LeagueService service = spy(leagueService);
+
+        doReturn(userId).when(currentUserProvider).clerkUserId();
+        doReturn(league).when(service).requireActiveLeague(leagueId);
+        doNothing().when(service).ensureCanView(league, userId);
+
+        LeagueTeam lt1 = mock(LeagueTeam.class);
+        LeagueTeam lt2 = mock(LeagueTeam.class);
+        LeagueTeam lt3 = mock(LeagueTeam.class);
+
+        when(lt1.getTeamId()).thenReturn(teamA);
+        when(lt2.getTeamId()).thenReturn(teamB);
+        when(lt3.getTeamId()).thenReturn(teamC);
+
+        when(leagueTeamRepository.findByLeague_IdOrderByCreatedAtDesc(leagueId))
+                .thenReturn(List.of(lt1, lt2, lt3));
+
+        LeagueMatch match1 = LeagueMatch.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .homeTeamId(teamA)
+                .awayTeamId(teamB)
+                .sport("soccer")
+                .startTime(OffsetDateTime.now().minusDays(2))
+                .endTime(OffsetDateTime.now().minusDays(2).plusHours(1))
+                .requiresReferee(false)
+                .status(LeagueMatchStatus.CONFIRMED)
+                .createdByUserId(userId)
+                .build();
+
+        LeagueMatch match2 = LeagueMatch.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .homeTeamId(teamB)
+                .awayTeamId(teamC)
+                .sport("soccer")
+                .startTime(OffsetDateTime.now().minusDays(1))
+                .endTime(OffsetDateTime.now().minusDays(1).plusHours(1))
+                .requiresReferee(false)
+                .status(LeagueMatchStatus.CONFIRMED)
+                .createdByUserId(userId)
+                .build();
+
+        when(leagueMatchRepository.findByLeague_IdOrderByStartTimeDesc(leagueId))
+                .thenReturn(List.of(match1, match2));
+
+        LeagueMatchScore score1 = LeagueMatchScore.builder()
+                .id(UUID.randomUUID())
+                .match(match1)
+                .homeScore(2)
+                .awayScore(1)
+                .submittedByUserId(userId)
+                .build();
+
+        LeagueMatchScore score2 = LeagueMatchScore.builder()
+                .id(UUID.randomUUID())
+                .match(match2)
+                .homeScore(0)
+                .awayScore(0)
+                .submittedByUserId(userId)
+                .build();
+
+        when(leagueMatchScoreRepository.findByMatch_League_Id(leagueId))
+                .thenReturn(List.of(score1, score2));
+
+        List<StandingScore> standings = service.getLeagueStandings(leagueId);
+
+        assertThat(standings).hasSize(3);
+        assertThat(standings.stream().map(StandingScore::getTeamId).toList())
+                .containsExactly(teamA, teamB, teamC);
+
+        StandingScore teamAStanding = standings.stream()
+                .filter(score -> score.getTeamId().equals(teamA))
+                .findFirst()
+                .orElseThrow();
+
+        StandingScore teamBStanding = standings.stream()
+                .filter(score -> score.getTeamId().equals(teamB))
+                .findFirst()
+                .orElseThrow();
+
+        StandingScore teamCStanding = standings.stream()
+                .filter(score -> score.getTeamId().equals(teamC))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(teamAStanding.getPlayed()).isEqualTo(1);
+        assertThat(teamAStanding.getWins()).isEqualTo(1);
+        assertThat(teamAStanding.getDraws()).isZero();
+        assertThat(teamAStanding.getLosses()).isZero();
+        assertThat(teamAStanding.getGoalsFor()).isEqualTo(2);
+        assertThat(teamAStanding.getGoalsAgainst()).isEqualTo(1);
+        assertThat(teamAStanding.getGoalDifference()).isEqualTo(1);
+        assertThat(teamAStanding.getPoints()).isEqualTo(3);
+
+        assertThat(teamBStanding.getPlayed()).isEqualTo(2);
+        assertThat(teamBStanding.getWins()).isZero();
+        assertThat(teamBStanding.getDraws()).isEqualTo(1);
+        assertThat(teamBStanding.getLosses()).isEqualTo(1);
+        assertThat(teamBStanding.getGoalsFor()).isEqualTo(1);
+        assertThat(teamBStanding.getGoalsAgainst()).isEqualTo(2);
+        assertThat(teamBStanding.getGoalDifference()).isEqualTo(1);
+        assertThat(teamBStanding.getPoints()).isEqualTo(1);
+
+        assertThat(teamCStanding.getPlayed()).isEqualTo(1);
+        assertThat(teamCStanding.getWins()).isZero();
+        assertThat(teamCStanding.getDraws()).isEqualTo(1);
+        assertThat(teamCStanding.getLosses()).isZero();
+        assertThat(teamCStanding.getGoalsFor()).isZero();
+        assertThat(teamCStanding.getGoalsAgainst()).isZero();
+        assertThat(teamCStanding.getGoalDifference()).isZero();
+        assertThat(teamCStanding.getPoints()).isEqualTo(1);
+    }
+
+
+    @Test
+    void getLeagueStandings_ignoresMatchesWithoutSubmittedScores() {
+        UUID leagueId = UUID.randomUUID();
+        String userId = "user_1";
+
+        UUID teamA = UUID.randomUUID();
+        UUID teamB = UUID.randomUUID();
+
+        League league = League.builder()
+                .id(leagueId)
+                .name("Test League")
+                .sport("soccer")
+                .ownerUserId(userId)
+                .privacy(LeaguePrivacy.PUBLIC)
+                .level(LeagueLevel.COMPETITIVE)
+                .build();
+
+        LeagueService service = spy(leagueService);
+
+        doReturn(userId).when(currentUserProvider).clerkUserId();
+        doReturn(league).when(service).requireActiveLeague(leagueId);
+        doNothing().when(service).ensureCanView(league, userId);
+
+        LeagueTeam lt1 = mock(LeagueTeam.class);
+        LeagueTeam lt2 = mock(LeagueTeam.class);
+
+        when(lt1.getTeamId()).thenReturn(teamA);
+        when(lt2.getTeamId()).thenReturn(teamB);
+
+        when(leagueTeamRepository.findByLeague_IdOrderByCreatedAtDesc(leagueId))
+                .thenReturn(List.of(lt1, lt2));
+
+        LeagueMatch match = LeagueMatch.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .homeTeamId(teamA)
+                .awayTeamId(teamB)
+                .sport("soccer")
+                .startTime(OffsetDateTime.now())
+                .endTime(OffsetDateTime.now().plusHours(1))
+                .requiresReferee(false)
+                .status(LeagueMatchStatus.CONFIRMED)
+                .createdByUserId(userId)
+                .build();
+
+        when(leagueMatchRepository.findByLeague_IdOrderByStartTimeDesc(leagueId))
+                .thenReturn(List.of(match));
+
+        when(leagueMatchScoreRepository.findByMatch_League_Id(leagueId))
+                .thenReturn(Collections.emptyList());
+
+        List<StandingScore> standings = service.getLeagueStandings(leagueId);
+
+        assertThat(standings).hasSize(2);
+        assertThat(standings)
+                .allSatisfy(score -> {
+                    assertThat(score.getPlayed()).isZero();
+                    assertThat(score.getPoints()).isZero();
+                });
+    }
+
+
+    @Test
+    void getLeagueStandings_returnsEmpty_whenLeagueHasNoTeams() {
+        UUID leagueId = UUID.randomUUID();
+        String userId = "user_1";
+
+        League league = League.builder()
+                .id(leagueId)
+                .name("Test League")
+                .sport("soccer")
+                .ownerUserId(userId)
+                .privacy(LeaguePrivacy.PUBLIC)
+                .level(LeagueLevel.COMPETITIVE)
+                .build();
+
+        LeagueService service = spy(leagueService);
+
+        doReturn(userId).when(currentUserProvider).clerkUserId();
+        doReturn(league).when(service).requireActiveLeague(leagueId);
+        doNothing().when(service).ensureCanView(league, userId);
+
+        when(leagueTeamRepository.findByLeague_IdOrderByCreatedAtDesc(leagueId))
+                .thenReturn(Collections.emptyList());
+
+        when(leagueMatchRepository.findByLeague_IdOrderByStartTimeDesc(leagueId))
+                .thenReturn(Collections.emptyList());
+
+        when(leagueMatchScoreRepository.findByMatch_League_Id(leagueId))
+                .thenReturn(Collections.emptyList());
+
+        List<StandingScore> standings = service.getLeagueStandings(leagueId);
+
+        assertThat(standings).isEmpty();
+    }
+
+
+    @Test
+    void getLeagueStandings_ignoresMatchWhenTeamNotInLeague() {
+        UUID leagueId = UUID.randomUUID();
+        String userId = "user_1";
+
+        UUID teamA = UUID.randomUUID();
+        UUID teamB = UUID.randomUUID();
+
+        League league = League.builder()
+                .id(leagueId)
+                .name("Test League")
+                .sport("soccer")
+                .ownerUserId(userId)
+                .privacy(LeaguePrivacy.PUBLIC)
+                .level(LeagueLevel.COMPETITIVE)
+                .build();
+
+        LeagueService service = spy(leagueService);
+
+        doReturn(userId).when(currentUserProvider).clerkUserId();
+        doReturn(league).when(service).requireActiveLeague(leagueId);
+        doNothing().when(service).ensureCanView(league, userId);
+
+        LeagueTeam lt1 = mock(LeagueTeam.class);
+        when(lt1.getTeamId()).thenReturn(teamA);
+
+        when(leagueTeamRepository.findByLeague_IdOrderByCreatedAtDesc(leagueId))
+                .thenReturn(List.of(lt1));
+
+        LeagueMatch match = LeagueMatch.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .homeTeamId(teamA)
+                .awayTeamId(teamB)
+                .sport("soccer")
+                .startTime(OffsetDateTime.now())
+                .endTime(OffsetDateTime.now().plusHours(1))
+                .requiresReferee(false)
+                .status(LeagueMatchStatus.CONFIRMED)
+                .createdByUserId(userId)
+                .build();
+
+        when(leagueMatchRepository.findByLeague_IdOrderByStartTimeDesc(leagueId))
+                .thenReturn(List.of(match));
+
+        LeagueMatchScore score = LeagueMatchScore.builder()
+                .id(UUID.randomUUID())
+                .match(match)
+                .homeScore(3)
+                .awayScore(0)
+                .submittedByUserId(userId)
+                .build();
+
+        when(leagueMatchScoreRepository.findByMatch_League_Id(leagueId))
+                .thenReturn(List.of(score));
+
+        List<StandingScore> standings = service.getLeagueStandings(leagueId);
+
+        assertThat(standings).hasSize(1);
+        assertThat(standings.get(0).getPlayed()).isZero();
+        assertThat(standings.get(0).getPoints()).isZero();
     }
 }


### PR DESCRIPTION
## Description
1. Created a endpoint to retrieve, aggregate and calculate standings data to return to front end.
2. Employed a Strategy pattern to adapt to different sport types, where the default is base don soccer

## How was this tested?
[x] Manual tests
[x] Unit tests

1. Retrieving standing for a league containing two teams:
<img width="1372" height="832" alt="image" src="https://github.com/user-attachments/assets/4bf0f7f2-42eb-4dc7-9391-684348ec7e2f" />
