### PR TITLE
GH-372: Added Player Card POC

### DIFF
--- a/Frontend/components/play-maker/play-maker-area.tsx
+++ b/Frontend/components/play-maker/play-maker-area.tsx
@@ -1,22 +1,23 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { View, ActivityIndicator } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { PlayMakerBoard } from "@/components/play-maker/play-maker-board";
 import { ShapesTab } from "@/components/play-maker/shapes-tab";
-import type {
-  Shape,
-  ShapeTool,
-  PlayMakerAreaProps,
-} from "@/components/play-maker/model";
+import type { Shape, PersonShape } from "@/components/play-maker/model";
 import { scanBoard } from "@/components/play-maker/utils";
 import { useRenderPlayMakerShapes } from "@/hooks/use-render-play-maker-shapes";
 import { ClearShapesButton } from "@/components/play-maker/clear-shapes-button";
 import { PlayerAssignmentPanel } from "@/components/play-maker/player-assignment-panel";
 import { useGetTeamMembers } from "@/hooks/use-get-team-members/use-get-team-members";
 import { useTeamDetailContext } from "@/contexts/team-detail-context";
+import { PlayerCardsOverlay } from "@/components/play-maker/player-cards-overlay";
 
-type PlayMakerAreaWithCallbackProps = PlayMakerAreaProps & {
+type PlayMakerAreaWithCallbackProps = any & {
   onShapesChange?: (shapes: Shape[]) => void;
+};
+
+const isAssignedPersonShape = (shape: Shape): shape is PersonShape => {
+  return shape.type === "person" && !!shape.associatedPlayerId;
 };
 
 export const PlayMakerArea = ({
@@ -24,7 +25,7 @@ export const PlayMakerArea = ({
   boardConfig: BoardConfig,
   onShapesChange,
 }: PlayMakerAreaWithCallbackProps) => {
-  const [selectedTool, setSelectedTool] = useState<ShapeTool>("person");
+  const [selectedTool, setSelectedTool] = useState<any>("person");
   const [selectedShapeId, setSelectedShapeId] = useState<string | null>(null);
   const [shapes, setShapes] = useState<Shape[]>([]);
 
@@ -32,7 +33,6 @@ export const PlayMakerArea = ({
   const storageKey = `playmaker:${teamId}`;
   const { data, isLoading } = useGetTeamMembers(teamId);
 
-  // LOAD (when page opens) — only set if there is actual saved content
   useEffect(() => {
     (async () => {
       try {
@@ -49,19 +49,39 @@ export const PlayMakerArea = ({
     })();
   }, [storageKey]);
 
-  // Keep parent screen in sync with current shapes (used by Save button)
   useEffect(() => {
     onShapesChange?.(shapes);
   }, [shapes, onShapesChange]);
 
-  // SAVE (whenever shapes change)
   useEffect(() => {
     AsyncStorage.setItem(storageKey, JSON.stringify(shapes)).catch(() => {});
   }, [shapes, storageKey]);
 
-  const renderedShapes = useRenderPlayMakerShapes(shapes, selectedShapeId, (id) =>
-    setSelectedShapeId(id)
+  const assignedPersonShapes = useMemo(
+    () => shapes.filter(isAssignedPersonShape),
+    [shapes],
   );
+
+  const svgShapes = useMemo(
+    () =>
+      shapes.filter(
+        (shape) => !(shape.type === "person" && !!shape.associatedPlayerId),
+      ),
+    [shapes],
+  );
+
+  const renderedShapes = useRenderPlayMakerShapes(
+    svgShapes,
+    selectedShapeId,
+    setSelectedShapeId,
+  );
+
+  const playersById = useMemo(() => {
+    const members = Array.isArray(data) ? data : [];
+    return Object.fromEntries(
+      members.map((player: any) => [String(player.id), player]),
+    );
+  }, [data]);
 
   return (
     <View style={styles.container}>
@@ -78,8 +98,16 @@ export const PlayMakerArea = ({
               selectedTool,
               setShapes,
               selectedShapeId,
-              setSelectedShapeId
+              setSelectedShapeId,
             )
+          }
+          overlayChildren={
+            <PlayerCardsOverlay
+              shapes={assignedPersonShapes}
+              selectedShapeId={selectedShapeId}
+              onSelect={setSelectedShapeId}
+              playersById={playersById}
+            />
           }
         >
           {renderedShapes}

--- a/Frontend/components/play-maker/play-maker-board.tsx
+++ b/Frontend/components/play-maker/play-maker-board.tsx
@@ -1,12 +1,17 @@
+import React from "react";
 import { View, StyleSheet, Pressable } from "react-native";
-import { PlayMakerBoardProps } from "@/components/play-maker/model";
 import { DefaultBoard } from "@/components/play-maker/play-maker-board-configurations/play-maker-default-board";
+
+type ExtendedPlayMakerBoardProps = any & {
+  overlayChildren?: React.ReactNode;
+};
 
 export const PlayMakerBoard = ({
   onBoardPress,
   boardConfig: BoardConfig,
   children,
-}: PlayMakerBoardProps) => {
+  overlayChildren,
+}: ExtendedPlayMakerBoardProps) => {
   const BoardWrapper = BoardConfig ?? DefaultBoard;
 
   return (
@@ -21,6 +26,10 @@ export const PlayMakerBoard = ({
         }}
       >
         <BoardWrapper>{children}</BoardWrapper>
+
+        <View pointerEvents="box-none" style={styles.overlay}>
+          {overlayChildren}
+        </View>
       </Pressable>
     </View>
   );
@@ -35,5 +44,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "rgba(255,255,255,0.25)",
     overflow: "hidden",
+    position: "relative",
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
   },
 });

--- a/Frontend/components/play-maker/player-card.tsx
+++ b/Frontend/components/play-maker/player-card.tsx
@@ -1,0 +1,333 @@
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  ImageSourcePropType,
+  Pressable,
+} from "react-native";
+import { CardShell, CARD_WIDTH, CARD_HEIGHT } from "./shield-card";
+
+type Stat = {
+  label: string;
+  value: number;
+};
+
+type CardType = "gold" | "silver" | "bronze" | "special";
+
+type FifaStyleCardProps = {
+  rating: number;
+  name: string;
+  position: string;
+  team: string;
+  nation: string;
+  image?: ImageSourcePropType;
+  cardType?: CardType;
+  stats: [Stat, Stat, Stat, Stat, Stat, Stat];
+  scale?: number;
+  onPress?: () => void;
+};
+
+function getCardColors(cardType: CardType) {
+  switch (cardType) {
+    case "silver":
+      return {
+        top: "#d9dde3",
+        bottom: "#8d96a1",
+        border: "#e8edf2",
+        accent: "#5e6875",
+      };
+    case "bronze":
+      return {
+        top: "#c88b5a",
+        bottom: "#7e4727",
+        border: "#dfb08b",
+        accent: "#5f331c",
+      };
+    case "special":
+      return {
+        top: "#1d2240",
+        bottom: "#101426",
+        border: "#62d6ff",
+        accent: "#d7f7ff",
+      };
+    case "gold":
+    default:
+      return {
+        top: "#f6e7a8",
+        bottom: "#ba9442",
+        border: "#fff1ba",
+        accent: "#6a4d12",
+      };
+  }
+}
+
+export function FifaStyleCard({
+  rating,
+  name,
+  position,
+  team,
+  nation,
+  image,
+  cardType = "gold",
+  stats,
+  scale = 1,
+  onPress,
+}: FifaStyleCardProps) {
+  const colors = getCardColors(cardType);
+
+  const scaledWidth = CARD_WIDTH * scale;
+  const scaledHeight = CARD_HEIGHT * scale;
+
+  const card = (
+    <View
+      style={[
+        styles.viewport,
+        {
+          width: scaledWidth,
+          height: scaledHeight,
+        },
+      ]}
+    >
+      <View
+        style={[
+          styles.scaledRoot,
+          {
+            transform: [{ scale }],
+          },
+        ]}
+      >
+        <CardShell
+          topColor={colors.top}
+          bottomColor={colors.bottom}
+          borderColor={colors.border}
+        >
+          <View style={styles.content}>
+            <View style={styles.topSection}>
+              <View style={styles.leftMeta}>
+                <Text style={[styles.rating, { color: colors.accent }]}>
+                  {rating}
+                </Text>
+                <Text style={[styles.position, { color: colors.accent }]}>
+                  {position.toUpperCase()}
+                </Text>
+              </View>
+
+              <View style={styles.playerImageWrapper}>
+                {image ? (
+                  <Image
+                    source={image}
+                    style={styles.playerImage}
+                    resizeMode="contain"
+                  />
+                ) : (
+                  <View style={styles.placeholderImage}>
+                    <Text style={styles.placeholderText}>GO</Text>
+                  </View>
+                )}
+              </View>
+            </View>
+
+            <View style={styles.identitySection}>
+              <Text
+                style={[styles.name, { color: colors.accent }]}
+                numberOfLines={1}
+              >
+                {name}
+              </Text>
+
+              <View style={styles.subRow}>
+                <Text
+                  style={[styles.subText, { color: colors.accent }]}
+                  numberOfLines={1}
+                >
+                  {team}
+                </Text>
+                <Text style={[styles.dot, { color: colors.accent }]}>•</Text>
+                <Text
+                  style={[styles.subText, { color: colors.accent }]}
+                  numberOfLines={1}
+                >
+                  {nation}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.divider} />
+
+            <View style={styles.statsGrid}>
+              <View style={styles.statsColumn}>
+                <StatRow stat={stats[0]} accent={colors.accent} />
+                <StatRow stat={stats[1]} accent={colors.accent} />
+                <StatRow stat={stats[2]} accent={colors.accent} />
+              </View>
+
+              <View style={styles.statsColumn}>
+                <StatRow stat={stats[3]} accent={colors.accent} />
+                <StatRow stat={stats[4]} accent={colors.accent} />
+                <StatRow stat={stats[5]} accent={colors.accent} />
+              </View>
+            </View>
+          </View>
+        </CardShell>
+      </View>
+    </View>
+  );
+
+  if (!onPress) return card;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={8}
+      style={({ pressed }) => [
+        styles.pressable,
+        { width: scaledWidth, height: scaledHeight },
+        pressed && styles.pressed,
+      ]}
+    >
+      {card}
+    </Pressable>
+  );
+}
+
+function StatRow({ stat, accent }: { stat: Stat; accent: string }) {
+  return (
+    <View style={styles.statRow}>
+      <Text style={[styles.statValue, { color: accent }]}>{stat.value}</Text>
+      <Text style={[styles.statLabel, { color: accent }]}>{stat.label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pressable: {
+    overflow: "hidden",
+  },
+  pressed: {
+    opacity: 0.9,
+  },
+  viewport: {
+    overflow: "hidden",
+    position: "relative",
+  },
+  scaledRoot: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    transformOrigin: "top left" as any,
+  },
+  content: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 22,
+    justifyContent: "space-between",
+    backgroundColor: "transparent",
+  },
+  topSection: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    minHeight: 150,
+  },
+  leftMeta: {
+    width: 52,
+    alignItems: "center",
+    paddingTop: 6,
+  },
+  rating: {
+    fontSize: 34,
+    fontWeight: "900",
+    lineHeight: 36,
+  },
+  position: {
+    fontSize: 14,
+    fontWeight: "800",
+    marginTop: 4,
+  },
+  playerImageWrapper: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 150,
+  },
+  playerImage: {
+    width: 128,
+    height: 150,
+  },
+  placeholderImage: {
+    width: 116,
+    height: 136,
+    borderRadius: 16,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  placeholderText: {
+    color: "#ffffff",
+    fontWeight: "900",
+    fontSize: 28,
+    letterSpacing: 1,
+  },
+  identitySection: {
+    alignItems: "center",
+    marginTop: 2,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: "900",
+    textTransform: "uppercase",
+    maxWidth: "100%",
+  },
+  subRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 6,
+  },
+  subText: {
+    fontSize: 12,
+    fontWeight: "700",
+    maxWidth: 72,
+  },
+  dot: {
+    marginHorizontal: 6,
+    fontSize: 12,
+    fontWeight: "900",
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "rgba(255,255,255,0.35)",
+    marginVertical: 8,
+  },
+  statsGrid: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 10,
+    paddingBottom: 10,
+  },
+  statsColumn: {
+    width: "46%",
+  },
+  statRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginVertical: 4,
+  },
+  statValue: {
+    width: 34,
+    fontSize: 16,
+    fontWeight: "900",
+  },
+  statLabel: {
+    fontSize: 14,
+    fontWeight: "700",
+    textTransform: "uppercase",
+  },
+});

--- a/Frontend/components/play-maker/player-cards-overlay.tsx
+++ b/Frontend/components/play-maker/player-cards-overlay.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { View, StyleSheet, Text } from "react-native";
+import { FifaStyleCard } from "./player-card";
+import { CARD_WIDTH, CARD_HEIGHT } from "@/components/play-maker/shield-card";
+import type { PersonShape } from "@/components/play-maker/model";
+
+type PlayerCardsOverlayProps = {
+  shapes: PersonShape[];
+  selectedShapeId: string | null;
+  onSelect: (id: string) => void;
+  playersById?: Record<string, any>;
+};
+
+const getPlayerName = (player: any) => {
+  if (!player) return "Player";
+  return (
+    player.name ||
+    player.fullName ||
+    [player.firstName, player.lastName].filter(Boolean).join(" ") ||
+    "Player"
+  );
+};
+
+const getPlayerPosition = (player: any) => {
+  return (
+    player.position ||
+    player.primaryPosition ||
+    player.role ||
+    player.playerPosition ||
+    "N/A"
+  );
+};
+
+const getPlayerTeam = (player: any) => {
+  return player.team || player.teamName || player.club || "";
+};
+
+const getPlayerNation = (player: any) => {
+  return player.nation || player.country || player.nationality || "";
+};
+
+const getPlayerImage = (player: any) => {
+  return player.image || player.avatar || player.photo || undefined;
+};
+
+export function PlayerCardsOverlay({
+  shapes,
+  selectedShapeId,
+  onSelect,
+  playersById,
+}: PlayerCardsOverlayProps) {
+  const safePlayersById = playersById ?? {};
+
+  return (
+    <>
+      {shapes.map((shape) => {
+        const player = shape.associatedPlayerId
+          ? safePlayersById[String(shape.associatedPlayerId)]
+          : undefined;
+
+        if (!player) {
+          return (
+            <View
+              key={shape.id}
+              style={[
+                styles.fallback,
+                {
+                  left: shape.x - 34,
+                  top: shape.y - 14,
+                },
+              ]}
+              pointerEvents="none"
+            >
+              <Text style={styles.fallbackText}>No player</Text>
+            </View>
+          );
+        }
+
+        const isSelected = shape.id === selectedShapeId;
+        const scale = isSelected ? 0.26 : 0.15;
+
+        const cardWidth = CARD_WIDTH * scale;
+        const cardHeight = CARD_HEIGHT * scale;
+
+        return (
+          <View
+            key={shape.id}
+            style={[
+              styles.cardSlot,
+              {
+                left: shape.x - cardWidth / 2,
+                top: shape.y - cardHeight / 2,
+                width: cardWidth,
+                height: cardHeight,
+                zIndex: isSelected ? 2 : 1,
+              },
+            ]}
+            pointerEvents="box-none"
+          >
+            <FifaStyleCard
+              rating={player.rating ?? player.overall ?? 75}
+              name={getPlayerName(player)}
+              position={getPlayerPosition(player)}
+              team={getPlayerTeam(player)}
+              nation={getPlayerNation(player)}
+              image={getPlayerImage(player)}
+              cardType="special"
+              stats={[
+                { label: "PAC", value: player.pac ?? 70 },
+                { label: "SHO", value: player.sho ?? 70 },
+                { label: "PAS", value: player.pas ?? 70 },
+                { label: "DRI", value: player.dri ?? 70 },
+                { label: "DEF", value: player.def ?? 70 },
+                { label: "PHY", value: player.phy ?? 70 },
+              ]}
+              scale={scale}
+              onPress={() => onSelect(shape.id)}
+            />
+          </View>
+        );
+      })}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  cardSlot: {
+    position: "absolute",
+  },
+  fallback: {
+    position: "absolute",
+    backgroundColor: "rgba(255,0,0,0.7)",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  fallbackText: {
+    color: "white",
+    fontWeight: "700",
+    fontSize: 11,
+  },
+});

--- a/Frontend/components/play-maker/shield-card.tsx
+++ b/Frontend/components/play-maker/shield-card.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import MaskedView from "@react-native-masked-view/masked-view";
+import Svg, { Path } from "react-native-svg";
+
+export const CARD_WIDTH = 220;
+export const CARD_HEIGHT = 360;
+
+const shieldPath = `
+  M 42 12
+  Q 58 0 86 0
+  L 134 0
+  Q 162 0 178 12
+  Q 204 24 206 52
+  L 206 285
+  Q 206 308 186 320
+  L 110 360
+  L 34 320
+  Q 14 308 14 285
+  L 14 52
+  Q 16 24 42 12
+  Z
+`;
+
+type CardShellProps = {
+  children: React.ReactNode;
+  topColor: string;
+  bottomColor: string;
+  borderColor: string;
+};
+
+export function CardShell({
+  children,
+  topColor,
+  bottomColor,
+  borderColor,
+}: CardShellProps) {
+  return (
+    <View style={styles.wrapper}>
+      <MaskedView
+        style={styles.wrapper}
+        maskElement={
+          <Svg width={CARD_WIDTH} height={CARD_HEIGHT} viewBox="0 0 220 360">
+            <Path d={shieldPath} fill="black" />
+          </Svg>
+        }
+      >
+        <View style={styles.maskedContent}>
+          <View style={[styles.topBg, { backgroundColor: topColor }]} />
+          <View style={[styles.bottomBg, { backgroundColor: bottomColor }]} />
+          <View style={styles.shine1} />
+          <View style={styles.shine2} />
+          {children}
+        </View>
+      </MaskedView>
+
+      <Svg
+        width={CARD_WIDTH}
+        height={CARD_HEIGHT}
+        viewBox="0 0 220 360"
+        style={StyleSheet.absoluteFillObject}
+        pointerEvents="none"
+      >
+        <Path d={shieldPath} fill="none" stroke={borderColor} strokeWidth={3} />
+      </Svg>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    backgroundColor: "transparent",
+  },
+  maskedContent: {
+    flex: 1,
+    backgroundColor: "transparent",
+  },
+  topBg: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 150,
+  },
+  bottomBg: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: CARD_HEIGHT - 150,
+  },
+  shine1: {
+    position: "absolute",
+    top: 35,
+    left: -20,
+    width: 280,
+    height: 40,
+    backgroundColor: "rgba(255,255,255,0.10)",
+    transform: [{ rotate: "-18deg" }],
+  },
+  shine2: {
+    position: "absolute",
+    top: 65,
+    left: -20,
+    width: 280,
+    height: 14,
+    backgroundColor: "rgba(255,255,255,0.16)",
+    transform: [{ rotate: "-18deg" }],
+  },
+});

--- a/Frontend/hooks/use-render-play-maker-shapes.tsx
+++ b/Frontend/hooks/use-render-play-maker-shapes.tsx
@@ -19,6 +19,8 @@ const renderers: RendererMap = {
   select: () => null,
 
   person: (s, isSelected, _selectedId, onSelect) => {
+    if (s.associatedPlayerId) return null;
+
     const size = s.size ?? 28;
     const hitPadding = 8;
 
@@ -93,7 +95,8 @@ export const useRenderPlayMakerShapes = (
   return useMemo(() => {
     return shapes
       .map((s) => {
-        const isSelected = "id" in s && s.id === selectedShapeId;
+        const isSelected = s.id === selectedShapeId;
+
         switch (s.type) {
           case "person":
             return renderers.person(s, isSelected, selectedShapeId, onSelect);
@@ -125,7 +128,7 @@ const buildArrowPath = (
   const hx2 = x2 - headLength * Math.cos(angle + headAngle);
   const hy2 = y2 - headLength * Math.sin(angle + headAngle);
 
-  return `M ${x1} ${y1} L ${x2} ${y2} 
+  return `M ${x1} ${y1} L ${x2} ${y2}
           M ${x2} ${y2} L ${hx1} ${hy1}
           M ${x2} ${y2} L ${hx2} ${hy2}`;
 };


### PR DESCRIPTION
## Description
1. Added Player Cards POC for assigned players in the team. This was an attempt to elevated the Play Maker component. the card consists of Player info, stats (not implemented at the moment) and a card type (bronzer, silver, gold or special). When selected, the card scale increases for visibility. If a player does not have a profile image, then a default template is displayed

## How was this tested?
[n/a] unit tests (This willl be added once the POC is approved by the Front end team)
[x] Manual testing

**Screenshots**

1. Special card type 
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/f4bd25d9-691c-4376-a95f-1686149c7ef6" />

2. Gold card type
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/c351d650-13ab-4904-9dcd-7fa8fd0928f9" />

3. Silver card type
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/461602c5-54be-4e89-816e-e9e39c257b59" />

4. Bronze card type
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/fae3e609-ed7d-4623-8671-ccc0c630a204" />

5. Card changes size when not selected
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/8e338ea7-7ea9-4dfc-83af-1a0dcaa52363" />
