### PR TITLE
GH-374: Addressed Play Maker saving defect

### DIFF
--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
@@ -113,8 +113,11 @@ public class TeamController {
     }
 
     @PostMapping("/{teamId}/play-maker")
-    public ResponseEntity<UUID> createPlay(@Valid @RequestBody List<PlayItemDTO> items) {
-        return ResponseEntity.status(201).body(teamService.createPlay(items));
+    public ResponseEntity<UUID> createPlay(
+            @PathVariable("teamId") UUID teamId,
+            @RequestBody List<PlayItemDTO> items
+    ) {
+        return ResponseEntity.status(201).body(teamService.createPlay(items, teamId));
     }
 
     @GetMapping("/{teamId}/plays/{playId}")

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/service/TeamService.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/service/TeamService.java
@@ -522,7 +522,7 @@ public class TeamService {
 
 
     @Transactional
-    public UUID createPlay(List<PlayItemDTO> items) {
+    public UUID createPlay(List<PlayItemDTO> items, UUID teamId) {
 
         List<PlayItemDTO> safeItems = (items == null) ? List.of() : items;
 
@@ -534,8 +534,14 @@ public class TeamService {
 
         UUID playId = UUID.randomUUID();
 
+        requireActiveTeam(teamId);
+
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NotFoundException("Team not found"));
+
         Play play = Play.builder()
                 .id(playId)
+                .team(team)
                 .build();
 
         playRepository.save(play);

--- a/Backend/go-team-service/src/test/java/com/game/on/go_team_service/TeamServiceTest.java
+++ b/Backend/go-team-service/src/test/java/com/game/on/go_team_service/TeamServiceTest.java
@@ -404,8 +404,13 @@ class TeamServiceTest {
 
         when(playNodeRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
         when(playEdgeRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+        Team team = new Team();
+        team.setId(teamId);
 
-        UUID playId = teamService.createPlay(items);
+        when(teamRepository.findByIdAndDeletedAtIsNull(eq(teamId))).thenReturn(Optional.of(team));
+        
+        when(teamRepository.findById(eq(teamId))).thenReturn(Optional.of(team));
+        UUID playId = teamService.createPlay(items, teamId);
 
         verify(playRepository).save(playCaptor.capture());
         Play savedPlay = playCaptor.getValue();

--- a/Frontend/app/(contexts)/playmaker/[id]/index.tsx
+++ b/Frontend/app/(contexts)/playmaker/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 import {
   ActivityIndicator,
   RefreshControl,
@@ -16,6 +16,7 @@ import { Header } from "@/components/header/header";
 import { Button } from "@/components/ui/button";
 import { PageTitle } from "@/components/header/page-title";
 import type { Shape } from "@/components/play-maker/model";
+import { useMutation } from "@tanstack/react-query";
 
 import {
   GO_TEAM_SERVICE_ROUTES,
@@ -95,10 +96,23 @@ function PlayMakerContent() {
   } = useTeamDetailContext();
 
   const navigation = useNavigation();
+
+  const savePlayMutation = useMutation({
+    mutationFn: async (shapes: Shape[]) => {
+      const payload = toBackendPayload(shapes);
+      const route = GO_TEAM_SERVICE_ROUTES.CREATE_PLAY(teamId);
+      return api.post(route, payload);
+    },
+    onSuccess: () => {
+      Alert.alert("Saved", "Your play was saved successfully.");
+    },
+    onError: (err) => {
+      Alert.alert("Error while saving play:", errorToString(err));
+    },
+  });
   const api = useAxiosWithClerk();
 
   const latestShapesRef = useRef<Shape[]>([]);
-  const [saving, setSaving] = useState(false);
 
   const handleShapesChange = useCallback((shapes: Shape[]) => {
     latestShapesRef.current = shapes;
@@ -112,25 +126,18 @@ function PlayMakerContent() {
       return;
     }
 
-    setSaving(true);
-
-    try {
-      const payload = toBackendPayload(shapes);
-      const route = GO_TEAM_SERVICE_ROUTES.CREATE_PLAY(teamId);
-
-      await api.post(route, payload);
-
-      Alert.alert("Saved", "Your play was saved successfully.");
-    } catch (err) {
-      Alert.alert("Error while saving play:", errorToString(err));
-    } finally {
-      setSaving(false);
-    }
-  }, [api, teamId]);
+    savePlayMutation.mutate(shapes);
+  }, [savePlayMutation]);
 
   const headerTitle = useCallback(
-    () => <PlaymakerHeader title={title} saving={saving} onSave={onSave} />,
-    [title, saving, onSave],
+    () => (
+      <PlaymakerHeader
+        title={title}
+        saving={savePlayMutation.isPending}
+        onSave={onSave}
+      />
+    ),
+    [title, savePlayMutation.isPending, onSave],
   );
 
   useLayoutEffect(() => {

--- a/Frontend/components/play-maker/play-maker-area.tsx
+++ b/Frontend/components/play-maker/play-maker-area.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { View, ActivityIndicator } from "react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { PlayMakerBoard } from "@/components/play-maker/play-maker-board";
 import { ShapesTab } from "@/components/play-maker/shapes-tab";
 import type {
@@ -29,38 +28,17 @@ export const PlayMakerArea = ({
   const [shapes, setShapes] = useState<Shape[]>([]);
 
   const { id: teamId } = useTeamDetailContext();
-  const storageKey = `playmaker:${teamId}`;
   const { data, isLoading } = useGetTeamMembers(teamId);
-
-  // LOAD (when page opens) — only set if there is actual saved content
-  useEffect(() => {
-    (async () => {
-      try {
-        const saved = await AsyncStorage.getItem(storageKey);
-        if (!saved) return;
-
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          setShapes(parsed);
-        }
-      } catch {
-        // ignore
-      }
-    })();
-  }, [storageKey]);
 
   // Keep parent screen in sync with current shapes (used by Save button)
   useEffect(() => {
     onShapesChange?.(shapes);
   }, [shapes, onShapesChange]);
 
-  // SAVE (whenever shapes change)
-  useEffect(() => {
-    AsyncStorage.setItem(storageKey, JSON.stringify(shapes)).catch(() => {});
-  }, [shapes, storageKey]);
-
-  const renderedShapes = useRenderPlayMakerShapes(shapes, selectedShapeId, (id) =>
-    setSelectedShapeId(id)
+  const renderedShapes = useRenderPlayMakerShapes(
+    shapes,
+    selectedShapeId,
+    (id) => setSelectedShapeId(id),
   );
 
   return (
@@ -78,7 +56,7 @@ export const PlayMakerArea = ({
               selectedTool,
               setShapes,
               selectedShapeId,
-              setSelectedShapeId
+              setSelectedShapeId,
             )
           }
         >


### PR DESCRIPTION
## Description
1. Fixes an issue where the Play Maker save flow was not properly persisting teamId, causing saved plays to not be reliably linked to the correct team.
2. Refactors the save logic to use TanStack Query useMutation and proper cache handling instead of relying on AsyncStorage, ensuring consistency between local state, cache, and backend data.

## How was this tested?
[n/a] Unit test
[x] Manual tests (see screenshots)

**Screenshots**
1. Before 
<img width="747" height="98" alt="image" src="https://github.com/user-attachments/assets/c3e2a7ac-62a4-43cd-abb7-76de6a1883c3" />

2. After
<img width="970" height="477" alt="image" src="https://github.com/user-attachments/assets/8eeee216-792f-4e27-bf16-2b1679b50f15" />
