### PR TITLE
implement league match result processing and stats update

### DIFF
--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueMatchController.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueMatchController.java
@@ -6,6 +6,7 @@ import com.game.on.go_league_service.league.dto.LeagueMatchCreateRequest;
 import com.game.on.go_league_service.league.dto.LeagueMatchResponse;
 import com.game.on.go_league_service.league.dto.LeagueMatchScheduleValidationResponse;
 import com.game.on.go_league_service.league.dto.LeagueMatchScoreRequest;
+import com.game.on.go_league_service.league.dto.LeagueTeamStatsResponse;
 import com.game.on.go_league_service.league.service.LeagueMatchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -68,6 +69,12 @@ public class LeagueMatchController {
                                                              @PathVariable UUID matchId,
                                                              @Valid @RequestBody AssignRefereeRequest request) {
         return ResponseEntity.ok(leagueMatchService.assignReferee(leagueId, matchId, request));
+    }
+
+    @GetMapping("/{leagueId}/teams/{teamId}/stats")
+    public ResponseEntity<LeagueTeamStatsResponse> getTeamStats(@PathVariable UUID leagueId,
+                                                                @PathVariable UUID teamId) {
+        return ResponseEntity.ok(leagueMatchService.getTeamStats(leagueId, teamId));
     }
 
     @GetMapping("/matches/{teamId}")

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueMatchScoreRequest.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueMatchScoreRequest.java
@@ -3,12 +3,16 @@ package com.game.on.go_league_service.league.dto;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.OffsetDateTime;
+
 public record LeagueMatchScoreRequest(
         @NotNull(message = "homeScore is required")
         @Min(value = 0, message = "homeScore must be >= 0")
         Integer homeScore,
         @NotNull(message = "awayScore is required")
         @Min(value = 0, message = "awayScore must be >= 0")
-        Integer awayScore
+        Integer awayScore,
+        @NotNull(message = "endTime is required")
+        OffsetDateTime endTime
 ) {
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueTeamStatsResponse.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueTeamStatsResponse.java
@@ -1,0 +1,13 @@
+package com.game.on.go_league_service.league.dto;
+
+import java.util.UUID;
+
+public record LeagueTeamStatsResponse(
+        UUID leagueId,
+        UUID teamId,
+        int points,
+        int matches,
+        int winStreak,
+        long minutesPlayed
+) {
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueMatchStatus.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueMatchStatus.java
@@ -2,5 +2,6 @@ package com.game.on.go_league_service.league.model;
 
 public enum LeagueMatchStatus {
     CONFIRMED,
+    COMPLETED,
     CANCELLED
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueMatchService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueMatchService.java
@@ -1,17 +1,13 @@
 package com.game.on.go_league_service.league.service;
 
 import com.game.on.go_league_service.client.TeamClient;
+import com.game.on.go_league_service.client.dto.TeamSummaryResponse;
 import com.game.on.go_league_service.config.CurrentUserProvider;
 import com.game.on.go_league_service.exception.BadRequestException;
 import com.game.on.go_league_service.exception.ConflictException;
 import com.game.on.go_league_service.exception.ForbiddenException;
 import com.game.on.go_league_service.exception.NotFoundException;
-import com.game.on.go_league_service.league.dto.AssignRefereeRequest;
-import com.game.on.go_league_service.league.dto.LeagueMatchCancelRequest;
-import com.game.on.go_league_service.league.dto.LeagueMatchCreateRequest;
-import com.game.on.go_league_service.league.dto.LeagueMatchResponse;
-import com.game.on.go_league_service.league.dto.LeagueMatchScheduleValidationResponse;
-import com.game.on.go_league_service.league.dto.LeagueMatchScoreRequest;
+import com.game.on.go_league_service.league.dto.*;
 import com.game.on.go_league_service.league.model.League;
 import com.game.on.go_league_service.league.model.LeagueMatch;
 import com.game.on.go_league_service.league.model.LeagueMatchScore;
@@ -29,12 +25,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -83,9 +77,6 @@ public class LeagueMatchService {
         League league = requireActiveLeague(leagueId);
         ensureLeagueOwner(league, userId);
 
-        if (Boolean.FALSE.equals(request.requiresReferee())) {
-            throw new BadRequestException("League matches require a referee");
-        }
         if (request.homeTeamId().equals(request.awayTeamId())) {
             throw new BadRequestException("homeTeamId and awayTeamId must be different");
         }
@@ -127,23 +118,30 @@ public class LeagueMatchService {
                 .scheduledDate(request.scheduledDate())
                 .matchLocation(venue.getName())
                 .venueId(venue.getId())
-                .requiresReferee(true)
+                .requiresReferee(Boolean.TRUE.equals(request.requiresReferee()))
                 .status(LeagueMatchStatus.CONFIRMED)
                 .createdByUserId(userId)
                 .build();
 
-        var referee = refereeProfileRepository.findById(request.refereeUserId())
-                .orElseThrow(() -> new NotFoundException("Referee not found"));
-        if (!referee.isActive()) {
-            throw new BadRequestException("Referee profile is inactive");
+        if (match.isRequiresReferee()) {
+            if (!StringUtils.hasText(request.refereeUserId())) {
+                throw new BadRequestException("refereeUserId is required when requiresReferee is true");
+            }
+
+            var referee = refereeProfileRepository.findById(request.refereeUserId())
+                    .orElseThrow(() -> new NotFoundException("Referee not found"));
+            if (!referee.isActive()) {
+                throw new BadRequestException("Referee profile is inactive");
+            }
+            ensureRefereeEligible(referee, match);
+            match.setRefereeUserId(referee.getUserId());
         }
-        ensureRefereeEligible(referee, match);
-        match.setRefereeUserId(referee.getUserId());
 
         var saved = leagueMatchRepository.save(match);
         log.info("league_match_created matchId={} leagueId={} byUser={}", saved.getId(), leagueId, userId);
         return toResponse(saved);
     }
+
 
     @Transactional(readOnly = true)
     public List<LeagueMatchResponse> listMatches(UUID leagueId) {
@@ -181,22 +179,28 @@ public class LeagueMatchService {
     @Transactional
     public void submitScore(UUID leagueId, UUID matchId, LeagueMatchScoreRequest request) {
         String userId = userProvider.clerkUserId();
-        League league = requireActiveLeague(leagueId);
+        requireActiveLeague(leagueId);
 
         var match = leagueMatchRepository.findByIdAndLeague_Id(matchId, leagueId)
                 .orElseThrow(() -> new NotFoundException("Match not found"));
+
+        if (match.getStatus() == LeagueMatchStatus.CANCELLED) {
+            throw new ConflictException("Cannot submit a score for a cancelled match");
+        }
+        if (match.getStatus() == LeagueMatchStatus.COMPLETED) {
+            throw new ConflictException("Final score already submitted");
+        }
 
         leagueMatchScoreRepository.findByMatch_Id(matchId).ifPresent(score -> {
             throw new ConflictException("Final score already submitted");
         });
 
-        if (StringUtils.hasText(match.getRefereeUserId())) {
-            if (!match.getRefereeUserId().equals(userId)) {
-                throw new ForbiddenException("Only the referee can submit the score");
-            }
-        } else if (!league.getOwnerUserId().equals(userId)) {
-            throw new ForbiddenException("Only the league owner can submit the score when no referee is assigned");
-        }
+        validateScoreSubmissionPermissions(match, userId);
+        validateSubmittedEndTime(match, request.endTime());
+
+        match.setEndTime(request.endTime());
+        match.setStatus(LeagueMatchStatus.COMPLETED);
+        leagueMatchRepository.save(match);
 
         LeagueMatchScore score = LeagueMatchScore.builder()
                 .match(match)
@@ -205,6 +209,63 @@ public class LeagueMatchService {
                 .submittedByUserId(userId)
                 .build();
         leagueMatchScoreRepository.save(score);
+    }
+
+    @Transactional(readOnly = true)
+    public LeagueTeamStatsResponse getTeamStats(UUID leagueId, UUID teamId) {
+        League league = requireActiveLeague(leagueId);
+        String userId = userProvider.clerkUserId();
+        if (!canViewLeague(league, userId)) {
+            throw new ForbiddenException("You do not have permission to view this league");
+        }
+        if (!leagueTeamRepository.existsByLeague_IdAndTeamId(leagueId, teamId)) {
+            throw new NotFoundException("Team is not part of this league");
+        }
+
+        List<LeagueMatch> completedMatches = leagueMatchRepository.findByLeague_IdOrderByStartTimeDesc(leagueId)
+                .stream()
+                .filter(match -> match.getStatus() == LeagueMatchStatus.COMPLETED)
+                .filter(match -> teamId.equals(match.getHomeTeamId()) || teamId.equals(match.getAwayTeamId()))
+                .sorted(Comparator.comparing(LeagueMatch::getStartTime))
+                .toList();
+
+        int points = 0;
+        int matches = 0;
+        int currentWinStreak = 0;
+        long minutesPlayed = 0;
+
+        for (LeagueMatch match : completedMatches) {
+            LeagueMatchScore score = leagueMatchScoreRepository.findByMatch_Id(match.getId()).orElse(null);
+            if (score == null) {
+                continue;
+            }
+
+            matches++;
+            minutesPlayed += calculateMinutesPlayed(match);
+
+            boolean isHome = teamId.equals(match.getHomeTeamId());
+            int teamScore = isHome ? score.getHomeScore() : score.getAwayScore();
+            int opponentScore = isHome ? score.getAwayScore() : score.getHomeScore();
+
+            if (teamScore > opponentScore) {
+                points += 3;
+                currentWinStreak++;
+            } else if (teamScore == opponentScore) {
+                points += 1;
+                currentWinStreak = 0;
+            } else {
+                currentWinStreak = 0;
+            }
+        }
+
+        return new LeagueTeamStatsResponse(
+                leagueId,
+                teamId,
+                points,
+                matches,
+                currentWinStreak,
+                minutesPlayed
+        );
     }
 
     @Transactional
@@ -274,6 +335,24 @@ public class LeagueMatchService {
     private void ensureLeagueOwner(League league, String userId) {
         if (!league.getOwnerUserId().equals(userId)) {
             throw new ForbiddenException("Only the league owner can perform this action");
+        }
+    }
+
+    private boolean canViewLeague(League league, String userId) {
+        if (league.getOwnerUserId().equals(userId)) {
+            return true;
+        }
+
+        try {
+            var memberships = teamClient.listTeams(true).items();
+            if (memberships == null || memberships.isEmpty()) {
+                return false;
+            }
+            var teamIds = memberships.stream().map(item -> item.id()).toList();
+            return leagueTeamRepository.existsByLeague_IdAndTeamIdIn(league.getId(), teamIds);
+        } catch (Exception ex) {
+            log.error("Failed to fetch current user teams while checking league visibility", ex);
+            return false;
         }
     }
 
@@ -411,5 +490,43 @@ public class LeagueMatchService {
             return trimToNull(venueService.requireVenue(match.getVenueId()).getRegion());
         }
         return trimToNull(match.getMatchLocation());
+    }
+
+    private void validateScoreSubmissionPermissions(LeagueMatch match, String userId) {
+        if (match.isRequiresReferee()) {
+            if (!StringUtils.hasText(match.getRefereeUserId())) {
+                throw new ConflictException("A referee must be assigned before the score can be submitted");
+            }
+            if (!match.getRefereeUserId().equals(userId)) {
+                throw new ForbiddenException("Only the assigned referee can submit the score");
+            }
+            return;
+        }
+
+        TeamSummaryResponse homeTeam = teamClient.getTeam(match.getHomeTeamId());
+        TeamSummaryResponse awayTeam = teamClient.getTeam(match.getAwayTeamId());
+        boolean isHomeOwner = userId.equals(homeTeam.ownerUserId());
+        boolean isAwayOwner = userId.equals(awayTeam.ownerUserId());
+
+        if (!isHomeOwner && !isAwayOwner) {
+            throw new ForbiddenException("Only one of the team owners can submit the score when no referee is required");
+        }
+    }
+
+    private void validateSubmittedEndTime(LeagueMatch match, OffsetDateTime submittedEndTime) {
+        if (submittedEndTime == null) {
+            throw new BadRequestException("endTime is required");
+        }
+        if (!match.getStartTime().isBefore(submittedEndTime)) {
+            throw new BadRequestException("endTime must be after the match startTime");
+        }
+    }
+
+    private long calculateMinutesPlayed(LeagueMatch match) {
+        if (match.getStartTime() == null || match.getEndTime() == null) {
+            return 0;
+        }
+        long minutes = Duration.between(match.getStartTime(), match.getEndTime()).toMinutes();
+        return Math.max(minutes, 0);
     }
 }

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueMatchServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueMatchServiceTest.java
@@ -6,7 +6,6 @@ import com.game.on.go_league_service.client.dto.TeamSummaryResponse;
 import com.game.on.go_league_service.config.CurrentUserProvider;
 import com.game.on.go_league_service.exception.BadRequestException;
 import com.game.on.go_league_service.exception.ConflictException;
-import com.game.on.go_league_service.exception.ForbiddenException;
 import com.game.on.go_league_service.league.dto.AssignRefereeRequest;
 import com.game.on.go_league_service.league.dto.LeagueMatchCreateRequest;
 import com.game.on.go_league_service.league.dto.LeagueMatchScheduleValidationResponse;
@@ -306,12 +305,23 @@ class LeagueMatchServiceTest {
         LeagueMatch match = new LeagueMatch();
         match.setId(UUID.randomUUID());
         match.setLeague(league);
+        match.setRequiresReferee(false);
         match.setRefereeUserId(null);
+        match.setHomeTeamId(homeTeamId);
+        match.setAwayTeamId(awayTeamId);
 
         when(leagueMatchRepository.findByIdAndLeague_Id(match.getId(), leagueId)).thenReturn(Optional.of(match));
         when(leagueMatchScoreRepository.findByMatch_Id(match.getId())).thenReturn(Optional.empty());
+        when(teamClient.getTeam(homeTeamId)).thenReturn(new TeamSummaryResponse(homeTeamId, "soccer", List.of("Montreal"), "owner_1"));
+        when(teamClient.getTeam(awayTeamId)).thenReturn(new TeamSummaryResponse(awayTeamId, "soccer", List.of("Montreal"), "owner_2"));
 
-        LeagueMatchScoreRequest request = new LeagueMatchScoreRequest(2, 1);
+        match.setStartTime(OffsetDateTime.parse("2026-03-20T09:00:00Z"));
+
+        LeagueMatchScoreRequest request = new LeagueMatchScoreRequest(
+                2,
+                1,
+                OffsetDateTime.parse("2026-03-20T10:30:00Z")
+        );
 
         leagueMatchService.submitScore(leagueId, match.getId(), request);
         verify(leagueMatchScoreRepository).save(any(LeagueMatchScore.class));


### PR DESCRIPTION
Developed with the assistance of ChatGPT

## Description
Implemented backend functionality for submitting league match scores and computing team statistics in the league microservice.

---

##  Features Implemented

###  Match Score Submission
- Endpoint:
  `POST /api/v1/leagues/{leagueId}/matches/{matchId}/score`
- Accepts:
  - `homeScore`
  - `awayScore`
  - `endTime`
- Updates:
  - Match `endTime`
  - Match status → `COMPLETED`
 
Requires referee (without referee authorization)
<img width="1079" height="569" alt="requires referee (without referee authorization)" src="https://github.com/user-attachments/assets/e6a2ea1c-0402-441b-bc45-8244b46e02b0" />
Requires referee (with referee authorization)
<img width="1073" height="463" alt="requires referee (with referee authorization)" src="https://github.com/user-attachments/assets/0c2a3c7b-aa50-4e1b-8962-0519a9686478" />
Requires team owner (without team owner authorization)
<img width="1080" height="573" alt="requires team owner (without team owner authorization)" src="https://github.com/user-attachments/assets/d4b17a6c-e16c-4c16-9fea-6f9496476165" />
Requires team owner (with team owner authorization)
<img width="1080" height="489" alt="requires team owner (with team owner authorization)" src="https://github.com/user-attachments/assets/eb03661c-05e6-438f-acfe-5dd098e8b6d4" />

---

###  Role-Based Submission Logic
- If `requiresReferee = true`
  - Only the assigned referee can submit the score
- If `requiresReferee = false`
  - One of the team owners must submit the score

---

###  Team Statistics Endpoint
- Endpoint:
  `GET /api/v1/leagues/{leagueId}/teams/{teamId}/stats`
- Returns:
  - `points`
  - `matches`
  - `winStreak`
  - `minutesPlayed`
- Stats are computed dynamically from completed matches (no DB persistence required)
<img width="1075" height="591" alt="stat" src="https://github.com/user-attachments/assets/78229f5c-afb9-41b0-8bba-9b4585b331f9" />

---

##  Technical Changes

- Updated:
  - `LeagueMatchService`
    - Score submission logic
    - Permission validation
    - Match status update
    - Team stats computation
  - `LeagueMatchController`
    - Added stats endpoint
  - `LeagueMatchScoreRequest`
    - Added `endTime`
  - `LeagueMatchStatus`
    - Added `COMPLETED`

- Added:
  - `LeagueTeamStatsResponse` DTO

- Updated tests:
  - `LeagueMatchServiceTest`

---

##  Testing

Tested using Postman:

### ✔️ Match Flow
- Create match (with and without referee)
- Submit score:
  - as referee
  - as team owner
- Prevent duplicate submissions

### ✔️ Validation
- Unauthorized users cannot submit scores
- Cannot submit score twice
- `endTime` must be after `startTime`

### ✔️ Stats Verification
- Win → +3 points
- Draw → +1 point
- Loss → 0 points
- Win streak updates correctly
- Minutes played calculated from match duration

---

##  Notes
- Stats are computed dynamically to avoid data inconsistency
- No database schema changes required
- Requires teams to be part of the league before match creation

---

##  Related Issue
Closes #376