### PR TITLE
GH-378: Addressed Play Maker player assignment defect

### DIFF
--- a/Frontend/components/play-maker/utils.ts
+++ b/Frontend/components/play-maker/utils.ts
@@ -109,15 +109,35 @@ export const addArrowBetweenShapes = (
   ]);
 };
 
-export const assignPlayerToShape = (playerId: string, selectedShapeId: string | null, shapes: Shape[], setShapes: React.Dispatch<React.SetStateAction<Shape[]>>) => {
+export const assignPlayerToShape = (
+  playerId: string,
+  selectedShapeId: string | null,
+  shapes: Shape[],
+  setShapes: React.Dispatch<React.SetStateAction<Shape[]>>
+) => {
   if (!selectedShapeId || !shapes) return;
 
-  setShapes(prevShapes =>
-    prevShapes.map(shape =>
-      shape.id === selectedShapeId ? { ...shape, associatedPlayerId: playerId } : shape
-    )
+  setShapes((prevShapes) =>
+    prevShapes.map((shape) => {
+      const shouldUnassign = shape.associatedPlayerId === playerId;
+      const shouldAssign = shape.id === selectedShapeId;
+
+      if (shouldUnassign && !shouldAssign) {
+        const { associatedPlayerId, ...rest } = shape;
+        return rest;
+      }
+
+      if (shouldAssign) {
+        return {
+          ...shape,
+          associatedPlayerId: playerId,
+        };
+      }
+
+      return shape;
+    })
   );
-}
+};
 
 const isEndpointShape = (shape: Shape): shape is EndpointShape => shape.type !== "arrow";
 


### PR DESCRIPTION
## Description
1. Modified player assignment logic in the Play Maker to properly handle reassigned Players.

## How was this tested?
[n/a] unit tests 
[x] Manual testing

**Screenshots**
1. Before


https://github.com/user-attachments/assets/f88dddbe-3af4-492b-93d9-d9bf4e0bd21f

2. After

https://github.com/user-attachments/assets/8855e866-208b-4187-8bcf-81bbd7d3aea4

