### PR TITLE
GH-392: [feat] add REPLACEMENT to team role management list

### DIFF
--- a/Frontend/__tests__/hooks/search/use-search.test.ts
+++ b/Frontend/__tests__/hooks/search/use-search.test.ts
@@ -1,13 +1,13 @@
-jest.mock("expo-router", () => ({
-  router: { push: jest.fn() },
-}));
-
 import { act, renderHook } from "@testing-library/react-native";
 import type { SearchResult } from "@/constants/search";
 import { useSearch } from "@/hooks/search/use-search";
 import { useTeamResults } from "@/hooks/search/use-team-results";
 import { useLeagueResults } from "@/hooks/search/use-league-results";
 import { createScopedLog } from "@/utils/logger";
+
+jest.mock("expo-router", () => ({
+  router: { push: jest.fn() },
+}));
 
 jest.mock("@/hooks/search/use-team-results");
 jest.mock("@/hooks/search/use-league-results");
@@ -232,6 +232,70 @@ describe("useSearch", () => {
         resultCount: 3,
         mode: "teams",
         tookMs: 12,
+      }),
+    );
+  });
+
+  it("notifyModeChange initializes then updates pending metadata", () => {
+    const info = jest.fn();
+    (createScopedLog as jest.Mock).mockReturnValue({ info, warn: jest.fn() });
+
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.notifyModeChange("leagues", 4);
+      result.current.notifyModeChange("teams", 2);
+      result.current.markRendered(7);
+    });
+
+    expect(info).toHaveBeenCalledWith(
+      "search completed",
+      expect.objectContaining({
+        query: "",
+        resultCount: 2,
+        tookMs: 7,
+      }),
+    );
+  });
+
+  it("logs mode-filtered count when mode is set before query update", () => {
+    const info = jest.fn();
+    (createScopedLog as jest.Mock).mockReturnValue({ info, warn: jest.fn() });
+
+    mockUseTeamResults.mockReturnValue({
+      data: [
+        baseTeamResult({ id: "t1", name: "alpha team" }),
+        baseTeamResult({ id: "t2", name: "beta team" }),
+      ],
+      raw: null,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: teamRefetch,
+    });
+
+    mockUseLeagueResults.mockReturnValue({
+      data: [baseLeagueResult({ id: "l1", name: "alpha league" })],
+      raw: null,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: leagueRefetch,
+    });
+
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.notifyModeChange("teams", 99);
+      result.current.setQuery("alpha");
+    });
+
+    expect(info).toHaveBeenLastCalledWith(
+      "search completed",
+      expect.objectContaining({
+        mode: "teams",
+        query: "alpha",
+        resultCount: 1,
       }),
     );
   });

--- a/Frontend/__tests__/hooks/use-header-height.test.ts
+++ b/Frontend/__tests__/hooks/use-header-height.test.ts
@@ -10,17 +10,11 @@ jest.mock("@react-navigation/elements", () => ({
 describe("use-header-height", () => {
   const mockedAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
   const mockedNavigationHeaderHeight = jest.mocked(useNavigationHeaderHeight);
-  const originalConsoleLog = console.log;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockedAsyncStorage.getItem.mockResolvedValue(null);
     mockedNavigationHeaderHeight.mockReturnValue(0);
-    console.log = jest.fn();
-  });
-
-  afterAll(() => {
-    console.log = originalConsoleLog;
   });
 
   it("returns the live navigation height when it is a positive whole number", () => {

--- a/Frontend/__tests__/utils/match-details.test.ts
+++ b/Frontend/__tests__/utils/match-details.test.ts
@@ -1,18 +1,40 @@
 import {
+  getDirectLeagueMatchId,
+  getResolvedMatchLeagueId,
+  getTeamSpaceId,
+  getDisplayMatch,
+  hasRespondedToAttendance,
+  getTeamPresentation,
   isLeagueMatch,
   getMatchLeagueId,
   getMatchTeamIds,
   canUserCancelMatch,
   canUserSubmitMatchScore,
   getMatchAttendanceAction,
+  getMatchAttendanceActionWithTitle,
   getContextLabel,
   getIsMatchLoading,
   getMatchScores,
+  getMatchVenuePresentation,
+  getMatchToolbarVisibility,
+  cancelMatch,
+  submitMatchAttendance,
+  openMatchVenueDirections,
+  showMatchVenueDirectionsPrompt,
+  showMatchAttendanceConfirm,
+  showCancelMatchConfirm,
 } from "@/utils/match-details";
-import type { MatchDetailsDisplayMatch, MatchTeamSummaryMap } from "@/types/match-details";
-import type { TeamMatch } from "@/types/matches";
+import { MATCH_ATTENDANCE_ACTIONS } from "@/constants/match-details";
+import type {
+  MatchDetailsDisplayMatch,
+  MatchTeamSummaryMap,
+} from "@/types/match-details";
+import type { TeamMatch, Venue } from "@/types/matches";
+import { Alert, Linking } from "react-native";
 
-const futureStartTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+const futureStartTime = new Date(
+  Date.now() + 24 * 60 * 60 * 1000,
+).toISOString();
 const pastStartTime = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
 type MatchWithUnknownScores = Omit<TeamMatch, "homeScore" | "awayScore"> & {
@@ -41,6 +63,233 @@ const leagueMatch: MatchDetailsDisplayMatch & { leagueId: string } = {
 };
 
 describe("match-details utils", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("league/team id resolution helpers", () => {
+    it("resolves direct and fallback league ids", () => {
+      expect(
+        getDirectLeagueMatchId({ space: "league", spaceId: "league-2" }),
+      ).toBe("league-2");
+      expect(
+        getDirectLeagueMatchId({
+          fallbackDisplayMatch: leagueMatch,
+          space: "team",
+          spaceId: "team-1",
+        }),
+      ).toBe("league-1");
+
+      expect(
+        getResolvedMatchLeagueId({
+          displayMatch: leagueMatch,
+          space: "team",
+          spaceId: "team-1",
+        }),
+      ).toBe("league-1");
+      expect(
+        getResolvedMatchLeagueId({ space: "league", spaceId: "league-3" }),
+      ).toBe("league-3");
+      expect(
+        getResolvedMatchLeagueId({ space: "team", spaceId: "team-1" }),
+      ).toBe("");
+    });
+
+    it("returns team space id only in team space", () => {
+      expect(getTeamSpaceId("team", "team-1")).toBe("team-1");
+      expect(getTeamSpaceId("league", "team-1")).toBe("");
+      expect(getTeamSpaceId(undefined, "team-1")).toBe("");
+    });
+  });
+
+  describe("display and attendance derivation", () => {
+    it("finds display match from the proper list based on space", () => {
+      const teamListMatch = { ...baseMatch, id: "team-list-match" };
+      const leagueListMatch = { ...leagueMatch, id: "league-list-match" };
+
+      expect(
+        getDisplayMatch({
+          matchId: "team-list-match",
+          space: "team",
+          teamMatches: [teamListMatch],
+        }),
+      ).toEqual(teamListMatch);
+
+      expect(
+        getDisplayMatch({
+          matchId: "league-list-match",
+          space: "league",
+          leagueMatches: [leagueListMatch],
+        }),
+      ).toEqual(leagueListMatch);
+    });
+
+    it("derives attendance response from role-specific persisted status", () => {
+      expect(hasRespondedToAttendance({ hasSubmittedAttendance: true })).toBe(
+        true,
+      );
+      expect(
+        hasRespondedToAttendance({
+          hasSubmittedAttendance: false,
+          role: "REPLACEMENT",
+          persistedAttendanceStatus: "CONFIRMED",
+        }),
+      ).toBe(true);
+      expect(
+        hasRespondedToAttendance({
+          hasSubmittedAttendance: false,
+          role: "PLAYER",
+          persistedAttendanceStatus: "DECLINED",
+        }),
+      ).toBe(true);
+      expect(
+        hasRespondedToAttendance({
+          hasSubmittedAttendance: false,
+          role: "PLAYER",
+          persistedAttendanceStatus: "PENDING",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("presentation helpers", () => {
+    it("builds team presentation from summary map with fallback defaults", () => {
+      const teamSummaryMap: MatchTeamSummaryMap = {
+        "team-1": {
+          id: "team-1",
+          name: "Home Team",
+          logoUrl: "home-logo",
+          ownerUserId: "owner-1",
+        },
+      };
+
+      expect(
+        getTeamPresentation({
+          displayMatch: baseMatch,
+          teamSummaryMap,
+          awayName: " Away Trim ",
+          awayLogoUrl: " away-logo ",
+          homeName: " Home Trim ",
+          homeLogoUrl: " home-fallback ",
+        }),
+      ).toEqual({
+        awayTeamLogoUrl: "away-logo",
+        awayTeamName: "Away Trim",
+        homeTeamLogoUrl: "home-logo",
+        homeTeamName: "Home Team",
+      });
+    });
+
+    it("adds title to attendance action when an action exists", () => {
+      expect(
+        getMatchAttendanceActionWithTitle({
+          awayTeamName: "Away",
+          displayMatch: baseMatch,
+          hasResponded: false,
+          homeTeamName: "Home",
+          isActiveMember: true,
+          role: "PLAYER",
+          space: "team",
+          spaceId: "team-1",
+        }),
+      ).toMatchObject({
+        ...MATCH_ATTENDANCE_ACTIONS.PLAYER,
+        title: "Home vs Away",
+      });
+
+      expect(
+        getMatchAttendanceActionWithTitle({
+          awayTeamName: "Away",
+          displayMatch: baseMatch,
+          hasResponded: true,
+          homeTeamName: "Home",
+          isActiveMember: true,
+          role: "PLAYER",
+          space: "team",
+          spaceId: "team-1",
+        }),
+      ).toBeNull();
+    });
+
+    it("builds venue presentation with and without coordinates", () => {
+      const venue: Venue = {
+        id: "venue-1",
+        name: "Main Field",
+        street: "123 Main St",
+        city: "Halifax",
+        region: "Halifax Regional Municipality",
+        province: "NS",
+        postalCode: "B3H 1Y6",
+        country: "Canada",
+        latitude: 44.65,
+        longitude: -63.57,
+        createdByUserId: "user-1",
+        createdAt: futureStartTime,
+        updatedAt: futureStartTime,
+      };
+
+      expect(
+        getMatchVenuePresentation({ displayMatch: baseMatch, venue }),
+      ).toEqual({
+        hasCoordinates: true,
+        hasVenue: true,
+        mapRegion: {
+          latitude: 44.65,
+          longitude: -63.57,
+          latitudeDelta: 0.01,
+          longitudeDelta: 0.01,
+        },
+        venueMetaLabel: "Main Field, Halifax, NS",
+      });
+
+      expect(
+        getMatchVenuePresentation({
+          displayMatch: { ...baseMatch, matchLocation: "Community Park" },
+          venue: null,
+        }),
+      ).toEqual({
+        hasCoordinates: false,
+        hasVenue: true,
+        mapRegion: undefined,
+        venueMetaLabel: "Community Park",
+      });
+    });
+
+    it("computes toolbar visibility combinations", () => {
+      expect(
+        getMatchToolbarVisibility({
+          attendanceAction: null,
+          canCancel: true,
+          canSubmitScore: true,
+          hasDisplayMatch: true,
+          hasScore: false,
+          isCancelled: false,
+        }),
+      ).toEqual({
+        showAttendanceInMenu: false,
+        showCancelInMenu: true,
+        showMatchScoreInMenu: true,
+        showMenu: true,
+      });
+
+      expect(
+        getMatchToolbarVisibility({
+          attendanceAction: null,
+          canCancel: false,
+          canSubmitScore: false,
+          hasDisplayMatch: false,
+          hasScore: true,
+          isCancelled: true,
+        }),
+      ).toEqual({
+        showAttendanceInMenu: false,
+        showCancelInMenu: false,
+        showMatchScoreInMenu: false,
+        showMenu: false,
+      });
+    });
+  });
+
   describe("isLeagueMatch", () => {
     it("returns true if match has leagueId", () => {
       expect(isLeagueMatch(leagueMatch)).toBe(true);
@@ -72,9 +321,11 @@ describe("match-details utils", () => {
     it("returns empty array if match is null", () => {
       expect(getMatchTeamIds(null)).toEqual([]);
     });
-    
+
     it("filters out falsy team IDs", () => {
-      expect(getMatchTeamIds({ ...baseMatch, awayTeamId: "" })).toEqual(["team-1"]);
+      expect(getMatchTeamIds({ ...baseMatch, awayTeamId: "" })).toEqual([
+        "team-1",
+      ]);
     });
   });
 
@@ -85,61 +336,77 @@ describe("match-details utils", () => {
     };
 
     it("returns false if match is null or missing", () => {
-      expect(canUserCancelMatch({ match: null, userId: "u1", isLeagueOwner: false })).toBe(false);
+      expect(
+        canUserCancelMatch({ match: null, userId: "u1", isLeagueOwner: false }),
+      ).toBe(false);
     });
 
     it("returns false if past match or cancelled", () => {
-      expect(canUserCancelMatch({
-        match: { ...baseMatch, startTime: pastStartTime },
-        userId: "user-owner",
-        isLeagueOwner: false,
-        teamSummaryMap,
-      })).toBe(false);
+      expect(
+        canUserCancelMatch({
+          match: { ...baseMatch, startTime: pastStartTime },
+          userId: "user-owner",
+          isLeagueOwner: false,
+          teamSummaryMap,
+        }),
+      ).toBe(false);
 
-      expect(canUserCancelMatch({
-        match: { ...baseMatch, status: "CANCELLED" },
-        userId: "user-owner",
-        isLeagueOwner: false,
-        teamSummaryMap,
-      })).toBe(false);
+      expect(
+        canUserCancelMatch({
+          match: { ...baseMatch, status: "CANCELLED" },
+          userId: "user-owner",
+          isLeagueOwner: false,
+          teamSummaryMap,
+        }),
+      ).toBe(false);
     });
 
     it("for league match: returns true only if isLeagueOwner", () => {
-      expect(canUserCancelMatch({
-        match: leagueMatch,
-        userId: "random-user",
-        isLeagueOwner: true,
-      })).toBe(true);
+      expect(
+        canUserCancelMatch({
+          match: leagueMatch,
+          userId: "random-user",
+          isLeagueOwner: true,
+        }),
+      ).toBe(true);
 
-      expect(canUserCancelMatch({
-        match: leagueMatch,
-        userId: "user-owner",
-        isLeagueOwner: false,
-        teamSummaryMap,
-      })).toBe(false);
+      expect(
+        canUserCancelMatch({
+          match: leagueMatch,
+          userId: "user-owner",
+          isLeagueOwner: false,
+          teamSummaryMap,
+        }),
+      ).toBe(false);
     });
 
     it("for team match: returns true if user is owner of home or away team", () => {
-      expect(canUserCancelMatch({
-        match: baseMatch,
-        userId: "user-owner",
-        isLeagueOwner: false,
-        teamSummaryMap,
-      })).toBe(true);
+      expect(
+        canUserCancelMatch({
+          match: baseMatch,
+          userId: "user-owner",
+          isLeagueOwner: false,
+          teamSummaryMap,
+        }),
+      ).toBe(true);
 
-      expect(canUserCancelMatch({
-        match: baseMatch,
-        userId: "other-owner",
-        isLeagueOwner: false,
-        teamSummaryMap,
-      })).toBe(true);
+      expect(
+        canUserCancelMatch({
+          match: baseMatch,
+          userId: "other-owner",
+          isLeagueOwner: false,
+          teamSummaryMap,
+        }),
+      ).toBe(true);
 
-      expect(canUserCancelMatch({
-        match: baseMatch,
-        userId: "random-user",
-        isLeagueOwner: false,
-        teamSummaryMap,
-      })).toBe(false);
+      expect(
+        canUserCancelMatch({
+          match: baseMatch,
+          userId: "random-user",
+          isLeagueOwner: false,
+          teamSummaryMap,
+        }),
+      ).toBe(false);
     });
   });
 
@@ -149,21 +416,56 @@ describe("match-details utils", () => {
     };
 
     it("returns false for invalid inputs, league matches, or unconfirmed matches", () => {
-      expect(canUserSubmitMatchScore({ match: null, userId: "u1" })).toBe(false);
-      expect(canUserSubmitMatchScore({ match: baseMatch, userId: null })).toBe(false);
-      expect(canUserSubmitMatchScore({ match: leagueMatch, userId: "u1" })).toBe(false);
-      expect(canUserSubmitMatchScore({ match: { ...baseMatch, status: "PENDING_TEAM_ACCEPTANCE" }, userId: "u1" })).toBe(false);
+      expect(canUserSubmitMatchScore({ match: null, userId: "u1" })).toBe(
+        false,
+      );
+      expect(canUserSubmitMatchScore({ match: baseMatch, userId: null })).toBe(
+        false,
+      );
+      expect(
+        canUserSubmitMatchScore({ match: leagueMatch, userId: "u1" }),
+      ).toBe(false);
+      expect(
+        canUserSubmitMatchScore({
+          match: { ...baseMatch, status: "PENDING_TEAM_ACCEPTANCE" },
+          userId: "u1",
+        }),
+      ).toBe(false);
     });
 
     it("returns true if requiresReferee is true and user is the referee", () => {
-      const refMatch = { ...baseMatch, requiresReferee: true, refereeUserId: "ref-user" };
-      expect(canUserSubmitMatchScore({ match: refMatch, userId: "ref-user" })).toBe(true);
-      expect(canUserSubmitMatchScore({ match: refMatch, userId: "user-owner", teamSummaryMap })).toBe(false);
+      const refMatch = {
+        ...baseMatch,
+        requiresReferee: true,
+        refereeUserId: "ref-user",
+      };
+      expect(
+        canUserSubmitMatchScore({ match: refMatch, userId: "ref-user" }),
+      ).toBe(true);
+      expect(
+        canUserSubmitMatchScore({
+          match: refMatch,
+          userId: "user-owner",
+          teamSummaryMap,
+        }),
+      ).toBe(false);
     });
 
     it("returns true if user is team owner for non-refereed match", () => {
-      expect(canUserSubmitMatchScore({ match: baseMatch, userId: "user-owner", teamSummaryMap })).toBe(true);
-      expect(canUserSubmitMatchScore({ match: baseMatch, userId: "random", teamSummaryMap })).toBe(false);
+      expect(
+        canUserSubmitMatchScore({
+          match: baseMatch,
+          userId: "user-owner",
+          teamSummaryMap,
+        }),
+      ).toBe(true);
+      expect(
+        canUserSubmitMatchScore({
+          match: baseMatch,
+          userId: "random",
+          teamSummaryMap,
+        }),
+      ).toBe(false);
     });
   });
 
@@ -228,27 +530,94 @@ describe("match-details utils", () => {
     });
 
     it("returns null for missing inputs or invalid spaces", () => {
-      expect(getMatchAttendanceAction({ match: null, space: "team", spaceId: "team-1", role: "PLAYER", isActiveMember: true, hasResponded: false })).toBeNull();
-      expect(getMatchAttendanceAction({ match: baseMatch, space: "league", spaceId: "team-1", role: "PLAYER", isActiveMember: true, hasResponded: false })).toBeNull();
-      expect(getMatchAttendanceAction({ match: baseMatch, space: "team", spaceId: undefined, role: "PLAYER", isActiveMember: true, hasResponded: false })).toBeNull();
-      expect(getMatchAttendanceAction({ match: baseMatch, space: "team", spaceId: "team-1", role: "PLAYER", isActiveMember: false, hasResponded: false })).toBeNull();
-      expect(getMatchAttendanceAction({ match: baseMatch, space: "team", spaceId: "team-1", role: "PLAYER", isActiveMember: true, hasResponded: true })).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: null,
+          space: "team",
+          spaceId: "team-1",
+          role: "PLAYER",
+          isActiveMember: true,
+          hasResponded: false,
+        }),
+      ).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: baseMatch,
+          space: "league",
+          spaceId: "team-1",
+          role: "PLAYER",
+          isActiveMember: true,
+          hasResponded: false,
+        }),
+      ).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: baseMatch,
+          space: "team",
+          spaceId: undefined,
+          role: "PLAYER",
+          isActiveMember: true,
+          hasResponded: false,
+        }),
+      ).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: baseMatch,
+          space: "team",
+          spaceId: "team-1",
+          role: "PLAYER",
+          isActiveMember: false,
+          hasResponded: false,
+        }),
+      ).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: baseMatch,
+          space: "team",
+          spaceId: "team-1",
+          role: "PLAYER",
+          isActiveMember: true,
+          hasResponded: true,
+        }),
+      ).toBeNull();
     });
 
     it("returns null if match is cancelled or in the past", () => {
-      expect(getMatchAttendanceAction({ match: { ...baseMatch, startTime: pastStartTime }, space: "team", spaceId: "team-1", role: "PLAYER", isActiveMember: true, hasResponded: false })).toBeNull();
-      expect(getMatchAttendanceAction({ match: { ...baseMatch, status: "CANCELLED" }, space: "team", spaceId: "team-1", role: "PLAYER", isActiveMember: true, hasResponded: false })).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: { ...baseMatch, startTime: pastStartTime },
+          space: "team",
+          spaceId: "team-1",
+          role: "PLAYER",
+          isActiveMember: true,
+          hasResponded: false,
+        }),
+      ).toBeNull();
+      expect(
+        getMatchAttendanceAction({
+          match: { ...baseMatch, status: "CANCELLED" },
+          space: "team",
+          spaceId: "team-1",
+          role: "PLAYER",
+          isActiveMember: true,
+          hasResponded: false,
+        }),
+      ).toBeNull();
     });
   });
 
   describe("getContextLabel", () => {
     it("returns league name if space is league", () => {
-      expect(getContextLabel({ space: "league", leagueName: "Pro League" })).toBe("Pro League");
+      expect(
+        getContextLabel({ space: "league", leagueName: "Pro League" }),
+      ).toBe("Pro League");
       expect(getContextLabel({ space: "league" })).toBe("League Match");
     });
 
     it("returns match league name if present for non-league spaces", () => {
-      expect(getContextLabel({ space: "team", matchLeagueName: "Fun League" })).toBe("Fun League");
+      expect(
+        getContextLabel({ space: "team", matchLeagueName: "Fun League" }),
+      ).toBe("Fun League");
     });
 
     it("falls back to default team label", () => {
@@ -318,11 +687,15 @@ describe("match-details utils", () => {
     });
 
     it("returns un-normalized scores if present", () => {
-      expect(getMatchScores({ ...baseMatch, homeScore: 3, awayScore: 1 })).toEqual({ homeScore: 3, awayScore: 1 });
+      expect(
+        getMatchScores({ ...baseMatch, homeScore: 3, awayScore: 1 }),
+      ).toEqual({ homeScore: 3, awayScore: 1 });
     });
 
     it("preserves null scores while pruning undefined/invalid", () => {
-      expect(getMatchScores({ ...baseMatch, homeScore: null, awayScore: null })).toEqual({ homeScore: null, awayScore: null });
+      expect(
+        getMatchScores({ ...baseMatch, homeScore: null, awayScore: null }),
+      ).toEqual({ homeScore: null, awayScore: null });
       expect(
         getMatchScores({
           ...baseMatch,
@@ -330,6 +703,149 @@ describe("match-details utils", () => {
           awayScore: undefined,
         } as unknown as MatchWithUnknownScores as MatchDetailsDisplayMatch),
       ).toEqual({ homeScore: undefined, awayScore: undefined });
+    });
+  });
+
+  describe("async actions and prompts", () => {
+    it("cancels league and team matches with expected invalidations", async () => {
+      const invalidateQueries = jest.fn().mockResolvedValue(undefined);
+      const cancelLeagueMatch = jest.fn().mockResolvedValue(undefined);
+      const cancelTeamMatch = jest.fn().mockResolvedValue(undefined);
+      const queryClient = { invalidateQueries } as unknown as {
+        invalidateQueries: (args: unknown) => Promise<unknown>;
+      };
+
+      await cancelMatch({
+        canCancel: true,
+        cancelLeagueMatch,
+        cancelTeamMatch,
+        displayMatch: leagueMatch,
+        leagueId: "league-1",
+        queryClient: queryClient as never,
+        space: "team",
+        spaceId: "team-1",
+      });
+
+      expect(cancelLeagueMatch).toHaveBeenCalledWith({ matchId: "match-1" });
+      expect(cancelTeamMatch).not.toHaveBeenCalled();
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["league-matches", "league-1"],
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["team-matches", "team-1"],
+      });
+
+      invalidateQueries.mockClear();
+      cancelLeagueMatch.mockClear();
+
+      await cancelMatch({
+        canCancel: true,
+        cancelLeagueMatch,
+        cancelTeamMatch,
+        displayMatch: baseMatch,
+        leagueId: "league-1",
+        queryClient: queryClient as never,
+        space: "team",
+        spaceId: "team-1",
+      });
+
+      expect(cancelTeamMatch).toHaveBeenCalledWith({ matchId: "match-1" });
+      expect(cancelLeagueMatch).not.toHaveBeenCalled();
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["team-match", "match-1"],
+      });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["team-matches", "team-1"],
+      });
+    });
+
+    it("submits attendance and invalidates match members", async () => {
+      const updateAttendance = jest.fn().mockResolvedValue(undefined);
+      const setHasSubmittedAttendance = jest.fn();
+      const invalidateQueries = jest.fn().mockResolvedValue(undefined);
+      const queryClient = { invalidateQueries } as unknown as {
+        invalidateQueries: (args: unknown) => Promise<unknown>;
+      };
+
+      await submitMatchAttendance({
+        attendanceAction: MATCH_ATTENDANCE_ACTIONS.PLAYER,
+        displayMatch: baseMatch,
+        queryClient: queryClient as never,
+        setHasSubmittedAttendance,
+        spaceId: "team-1",
+        updateAttendance,
+      });
+
+      expect(updateAttendance).toHaveBeenCalledWith({
+        matchId: "match-1",
+        attending: "DECLINED",
+      });
+      expect(setHasSubmittedAttendance).toHaveBeenCalledWith(true);
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["match-members-by-team", "match-1", "team-1"],
+      });
+    });
+
+    it("opens maps when available and alerts when unavailable", async () => {
+      const canOpenURLSpy = jest.spyOn(Linking, "canOpenURL");
+      const openURLSpy = jest
+        .spyOn(Linking, "openURL")
+        .mockResolvedValue(undefined);
+      const alertSpy = jest
+        .spyOn(Alert, "alert")
+        .mockImplementation(() => undefined);
+
+      canOpenURLSpy.mockResolvedValueOnce(true);
+      await openMatchVenueDirections({
+        hasCoordinates: true,
+        venue: {
+          id: "venue-1",
+          name: "Main Field",
+          street: "123 Main St",
+          city: "Halifax",
+          region: "Halifax Regional Municipality",
+          province: "NS",
+          postalCode: "B3H 1Y6",
+          country: "Canada",
+          latitude: 10,
+          longitude: 20,
+          createdByUserId: "user-1",
+          createdAt: futureStartTime,
+          updatedAt: futureStartTime,
+        } as Venue,
+      });
+      expect(openURLSpy).toHaveBeenCalledWith(
+        "https://maps.apple.com/?daddr=10,20&q=Main%20Field",
+      );
+
+      canOpenURLSpy.mockResolvedValueOnce(false);
+      await openMatchVenueDirections({
+        hasCoordinates: false,
+        matchLocation: "Community Park",
+      });
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Maps unavailable",
+        "Could not open Apple Maps for directions on this device.",
+      );
+    });
+
+    it("shows attendance and cancel confirmation prompts", () => {
+      const alertSpy = jest
+        .spyOn(Alert, "alert")
+        .mockImplementation(() => undefined);
+      const onConfirm = jest.fn();
+
+      showMatchVenueDirectionsPrompt({
+        venueName: "Main Field",
+        onOpen: jest.fn(),
+      });
+      showMatchAttendanceConfirm({
+        attendanceAction: MATCH_ATTENDANCE_ACTIONS.PLAYER,
+        onConfirm,
+      });
+      showCancelMatchConfirm(onConfirm);
+
+      expect(alertSpy).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/Frontend/__tests__/utils/messaging.test.ts
+++ b/Frontend/__tests__/utils/messaging.test.ts
@@ -8,9 +8,12 @@ import {
   formatMessageTimestamp,
   formatDateSeparator,
   maxMessageLength,
+  lastMessageId,
+  buildChatListRows,
 } from "@/utils/messaging/utils";
 import type { InfiniteData } from "@tanstack/react-query";
 import type {
+  ChatListRow,
   ConversationResponse,
   MessageHistoryResponse,
   MessageResponse,
@@ -455,5 +458,119 @@ describe("formatDateSeparator", () => {
       year: "numeric",
     }).format(target);
     expect(formatDateSeparator(target)).toBe(expected);
+  });
+});
+
+describe("lastMessageId", () => {
+  it("returns null when there are no message rows", () => {
+    expect(
+      lastMessageId([{ type: "date", id: "date-2026-0-1", label: "Today" }]),
+    ).toBeNull();
+  });
+
+  it("returns the id of the last message row", () => {
+    const rows: ChatListRow[] = [
+      { type: "date", id: "date-2026-0-1", label: "Today" },
+      {
+        type: "message" as const,
+        message: {
+          id: "msg-1",
+          text: "one",
+          fromMe: true,
+          createdAt: "2026-01-21T10:00:00Z",
+        },
+      },
+      {
+        type: "message" as const,
+        message: {
+          id: "msg-2",
+          text: "two",
+          fromMe: false,
+          senderLabel: "Alex",
+          createdAt: "2026-01-21T11:00:00Z",
+        },
+      },
+    ];
+
+    expect(lastMessageId(rows)).toBe("msg-2");
+  });
+});
+
+describe("buildChatListRows", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 1, 21, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("groups same-day messages under one date row and sets fromMe/sender labels", () => {
+    const messages: MessageResponse[] = [
+      {
+        id: "msg-1",
+        content: "mine",
+        createdAt: "2026-02-21T09:00:00Z",
+        conversationId: "conv-1",
+        senderId: "user-1",
+      },
+      {
+        id: "msg-2",
+        content: "theirs",
+        createdAt: "2026-02-21T10:00:00Z",
+        conversationId: "conv-1",
+        senderId: "user-2",
+      },
+    ];
+
+    const rows = buildChatListRows(
+      messages,
+      "user-1",
+      (senderId) => `name-${senderId}`,
+    );
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0].type).toBe("date");
+    expect(rows[1]).toMatchObject({
+      type: "message",
+      message: {
+        id: "msg-1",
+        fromMe: true,
+        senderLabel: undefined,
+      },
+    });
+    expect(rows[2]).toMatchObject({
+      type: "message",
+      message: {
+        id: "msg-2",
+        fromMe: false,
+        senderLabel: "name-user-2",
+      },
+    });
+  });
+
+  it("inserts a new date row when day changes", () => {
+    const messages: MessageResponse[] = [
+      {
+        id: "msg-1",
+        content: "older",
+        createdAt: "2026-02-20T10:00:00Z",
+        conversationId: "conv-1",
+        senderId: "user-2",
+      },
+      {
+        id: "msg-2",
+        content: "today",
+        createdAt: "2026-02-21T10:00:00Z",
+        conversationId: "conv-1",
+        senderId: "user-2",
+      },
+    ];
+
+    const rows = buildChatListRows(messages, "user-1", () => "Other");
+
+    expect(rows.filter((row) => row.type === "date")).toHaveLength(2);
+    expect(rows.filter((row) => row.type === "message")).toHaveLength(2);
   });
 });

--- a/Frontend/app/(app)/teams/[id]/settings/index.tsx
+++ b/Frontend/app/(app)/teams/[id]/settings/index.tsx
@@ -35,6 +35,7 @@ const TEAM_ROLE_OPTIONS: readonly TeamRole[] = [
   "MANAGER",
   "PLAYER",
   "COACH",
+  "REPLACEMENT",
 ] as const;
 
 function TeamSettingsToolbar() {
@@ -76,9 +77,9 @@ function getAssignableRoles(
 
   if (
     callerRole === "MANAGER" &&
-    (targetRole === "PLAYER" || targetRole === "COACH")
+    (targetRole === "PLAYER" || targetRole === "COACH" || targetRole === "REPLACEMENT")
   ) {
-    return ["PLAYER", "COACH"];
+    return ["PLAYER", "COACH", "REPLACEMENT"];
   }
 
   return [];

--- a/Frontend/hooks/search/use-search.ts
+++ b/Frontend/hooks/search/use-search.ts
@@ -59,10 +59,12 @@ export function useSearch(options?: UseSearchOptions): SearchValue {
   const leagueError = leagueQuery.error ?? null;
 
   useEffect(() => {
+    const pendingMode = lastSearchRef.current?.mode;
     lastSearchRef.current = {
       id: nextId.current++,
       query,
       resultCount: results.length,
+      mode: pendingMode,
     };
 
     let displayedCount = results.length;

--- a/Frontend/types/team-member.ts
+++ b/Frontend/types/team-member.ts
@@ -4,7 +4,7 @@ export type TeamMember = {
   id: string;
   joinedAt?: string | null;
   lastname: string;
-  role?: "OWNER" | "MANAGER" | "PLAYER" | "COACH";
+  role?: "OWNER" | "MANAGER" | "PLAYER" | "COACH" | "REPLACEMENT";
   userId?: string;
   imageUrl?: string | null;
 };


### PR DESCRIPTION
## Description

This pr will close #392.

(Made with the help of Copilot.)

1. Add "Replacement" to the List of Roles in Team Role Management
2. Improve overall test coverage

## How Was This Tested

- [x] Manual Test (see **Supporting Media**)
- [N/A] Unit Test

**Supporting Media**

- Demo

https://github.com/user-attachments/assets/53f494bf-7a24-43fa-9b6b-262e98ead3cf

- Updated database values

<img width="1045" height="51" alt="Screenshot 2026-04-01 at 3 25 05 PM" src="https://github.com/user-attachments/assets/46c96ace-f9ca-43d3-8a00-2ace72d6819e" />