### PR TITLE
Fix unauthenticated user creation endpoint and self-demote IDOR vulnerability

### DIFF
--- a/Backend/go-api-gateway/src/main/java/com/game/on/go_api_gateway/PublicEndpoints.java
+++ b/Backend/go-api-gateway/src/main/java/com/game/on/go_api_gateway/PublicEndpoints.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 public class PublicEndpoints {
 
     public static final String[] AUTH_WHITELIST = {
-            "/api/v1/user/create",
             "/api/v1/messaging/ws",
             "/api/v1/explore/league-matches",
             "/api/v1/explore/team-matches"

--- a/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
+++ b/Backend/go-team-service/src/main/java/com/game/on/go_team_service/team/controller/TeamController.java
@@ -1,5 +1,6 @@
 package com.game.on.go_team_service.team.controller;
 
+import com.game.on.go_team_service.config.CurrentUserProvider;
 import com.game.on.go_team_service.team.dto.*;
 import com.game.on.go_team_service.team.service.TeamService;
 import jakarta.validation.Valid;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public class TeamController {
 
     private final TeamService teamService;
+    private final CurrentUserProvider currentUserProvider;
 
     @PostMapping("/create")
     public ResponseEntity<TeamDetailResponse> createTeam(@Valid @RequestBody TeamCreateRequest request) {
@@ -99,9 +101,9 @@ public class TeamController {
         return ResponseEntity.ok(teamService.transferOwnership(request));
     }
 
-    @PostMapping("/{teamId}/members/self-demote/{userId}")
-    public ResponseEntity<TeamMemberResponse> demoteSelf(@PathVariable String userId, @PathVariable UUID teamId) {
-        return ResponseEntity.ok(teamService.demoteSelfToPlayer(teamId, userId));
+    @PostMapping("/{teamId}/members/self-demote")
+    public ResponseEntity<TeamMemberResponse> demoteSelf(@PathVariable UUID teamId) {
+        return ResponseEntity.ok(teamService.demoteSelfToPlayer(teamId, currentUserProvider.clerkUserId()));
     }
 
     @PatchMapping("/{teamId}/members/{userId}/role")


### PR DESCRIPTION
## Summary
- Remove `/api/v1/user/create` from the API Gateway public whitelist — the Clerk JWT is available at call time since `setActive` is awaited before `upsertUser.mutateAsync`, so this endpoint no longer needs to be unauthenticated
- Fix IDOR vulnerability in self-demote route: remove `userId` from the URL path and read the caller's identity from the JWT via `CurrentUserProvider` instead, preventing users from demoting arbitrary members

## Security impact
- **Gateway whitelist** — previously any unauthenticated request could hit the user creation endpoint; now a valid Bearer token is required
- **Self-demote IDOR** — previously `POST /{teamId}/members/self-demote/{userId}` accepted an arbitrary `userId` from the URL; the new route `POST /{teamId}/members/self-demote` derives the user ID from the authenticated JWT

## Test plan
- [ ] Sign up a new user end-to-end and confirm the profile is created without errors (verifies the JWT is attached when `/user/create` is called)
- [ ] Attempt to call `POST /api/v1/user/create` without a Bearer token — expect 401
- [ ] As a team member, call `POST /{teamId}/members/self-demote` and confirm only your own role is demoted
- [ ] Confirm no existing self-demote callers in the frontend pass a `userId` segment in the URL