### PR TITLE
GH-66 League Organizers Full Implementation

### DIFF
--- a/Backend/go-config-server/src/main/resources/configurations/go-api-gateway.yml
+++ b/Backend/go-config-server/src/main/resources/configurations/go-api-gateway.yml
@@ -26,7 +26,7 @@ spring:
             - id: go-league-invite-service
               uri: lb://go-league-service
               predicates:
-                - Path=/api/v1/teams/*/league-invites,/api/v1/league-invites/**
+                - Path=/api/v1/teams/*/league-invites,/api/v1/league-invites/**,/api/v1/league-organizer-invites/**
             - id: go-team-service
               uri: lb://go-team-service
               predicates:

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueOrganizerController.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueOrganizerController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerInviteResponse;
+
 
 import java.util.List;
 import java.util.UUID;
@@ -53,5 +55,10 @@ public class LeagueOrganizerController {
     public ResponseEntity<Void> decline(@PathVariable UUID inviteId) {
         organizerService.declineInvite(inviteId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/league-organizer-invites/mine")
+    public ResponseEntity<List<LeagueOrganizerInviteResponse>> myInvites() {
+        return ResponseEntity.ok(organizerService.listMyPendingInvites());
     }
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueOrganizerController.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/controller/LeagueOrganizerController.java
@@ -1,0 +1,57 @@
+package com.game.on.go_league_service.league.controller;
+
+import com.game.on.go_league_service.league.dto.LeagueOrganizerInviteCreateRequest;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerResponse;
+import com.game.on.go_league_service.league.service.LeagueOrganizerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class LeagueOrganizerController {
+
+    private final LeagueOrganizerService organizerService;
+
+    @GetMapping("/leagues/{leagueId}/organizers")
+    public ResponseEntity<List<LeagueOrganizerResponse>> list(@PathVariable UUID leagueId) {
+        return ResponseEntity.ok(organizerService.listOrganizers(leagueId));
+    }
+
+    @DeleteMapping("/leagues/{leagueId}/organizers/{userId}")
+    public ResponseEntity<Void> remove(@PathVariable UUID leagueId,
+                                       @PathVariable String userId) {
+        organizerService.removeOrganizer(leagueId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/leagues/{leagueId}/organizer-invites")
+    public ResponseEntity<Void> invite(@PathVariable UUID leagueId,
+                                       @Valid @RequestBody LeagueOrganizerInviteCreateRequest request) {
+        organizerService.createInvite(leagueId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/leagues/{leagueId}/organizer-invites/pending-ids")
+    public ResponseEntity<List<String>> pendingIds(@PathVariable UUID leagueId) {
+        return ResponseEntity.ok(organizerService.listPendingInviteeIds(leagueId));
+    }
+
+    @PostMapping("/league-organizer-invites/{inviteId}/accept")
+    public ResponseEntity<Void> accept(@PathVariable UUID inviteId) {
+        organizerService.acceptInvite(inviteId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/league-organizer-invites/{inviteId}/decline")
+    public ResponseEntity<Void> decline(@PathVariable UUID inviteId) {
+        organizerService.declineInvite(inviteId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueOrganizerInviteCreateRequest.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueOrganizerInviteCreateRequest.java
@@ -1,0 +1,7 @@
+package com.game.on.go_league_service.league.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LeagueOrganizerInviteCreateRequest(
+        @NotBlank String inviteeUserId
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueOrganizerInviteResponse.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueOrganizerInviteResponse.java
@@ -1,0 +1,14 @@
+package com.game.on.go_league_service.league.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record LeagueOrganizerInviteResponse(
+        UUID id,
+        UUID leagueId,
+        String inviteeUserId,
+        String invitedByUserId,
+        String status,
+        OffsetDateTime createdAt,
+        OffsetDateTime respondedAt
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueOrganizerResponse.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/dto/LeagueOrganizerResponse.java
@@ -1,0 +1,11 @@
+package com.game.on.go_league_service.league.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record LeagueOrganizerResponse(
+        UUID id,
+        UUID leagueId,
+        String userId,
+        OffsetDateTime joinedAt
+) {}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueOrganizer.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueOrganizer.java
@@ -1,0 +1,47 @@
+package com.game.on.go_league_service.league.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+@Entity
+@Table(name = "league_organizers")
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class LeagueOrganizer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @EqualsAndHashCode.Include
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "league_id", nullable = false)
+    private League league;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "joined_at", nullable = false)
+    private OffsetDateTime joinedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        if (joinedAt == null) joinedAt = OffsetDateTime.now();
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueOrganizerInvite.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueOrganizerInvite.java
@@ -1,0 +1,49 @@
+package com.game.on.go_league_service.league.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+@Entity
+@Table(name = "league_organizer_invites")
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class LeagueOrganizerInvite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @EqualsAndHashCode.Include
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "league_id", nullable = false)
+    private League league;
+
+    @Column(name = "invitee_user_id", nullable = false)
+    private String inviteeUserId;
+
+    @Column(name = "invited_by_user_id", nullable = false)
+    private String invitedByUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private LeagueOrganizerInviteStatus status;
+
+    @Column(name = "responded_at")
+    private OffsetDateTime respondedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueOrganizerInviteStatus.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/model/LeagueOrganizerInviteStatus.java
@@ -1,0 +1,7 @@
+package com.game.on.go_league_service.league.model;
+
+public enum LeagueOrganizerInviteStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerInviteRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerInviteRepository.java
@@ -1,0 +1,21 @@
+package com.game.on.go_league_service.league.repository;
+
+import com.game.on.go_league_service.league.model.LeagueOrganizerInvite;
+import com.game.on.go_league_service.league.model.LeagueOrganizerInviteStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LeagueOrganizerInviteRepository extends JpaRepository<LeagueOrganizerInvite, UUID> {
+
+    Optional<LeagueOrganizerInvite> findByLeague_IdAndInviteeUserIdAndStatus(
+            UUID leagueId, String inviteeUserId, LeagueOrganizerInviteStatus status);
+
+    List<LeagueOrganizerInvite> findByLeague_IdAndStatusOrderByCreatedAtDesc(
+            UUID leagueId, LeagueOrganizerInviteStatus status);
+
+    Optional<LeagueOrganizerInvite> findByIdAndStatus(
+            UUID id, LeagueOrganizerInviteStatus status);
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerInviteRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerInviteRepository.java
@@ -18,4 +18,7 @@ public interface LeagueOrganizerInviteRepository extends JpaRepository<LeagueOrg
 
     Optional<LeagueOrganizerInvite> findByIdAndStatus(
             UUID id, LeagueOrganizerInviteStatus status);
+
+    List<LeagueOrganizerInvite> findByInviteeUserIdAndStatusOrderByCreatedAtDesc(
+            String inviteeUserId, LeagueOrganizerInviteStatus status);
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerRepository.java
@@ -1,0 +1,17 @@
+package com.game.on.go_league_service.league.repository;
+
+import com.game.on.go_league_service.league.model.LeagueOrganizer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LeagueOrganizerRepository extends JpaRepository<LeagueOrganizer, UUID> {
+
+    List<LeagueOrganizer> findByLeague_IdOrderByJoinedAtAsc(UUID leagueId);
+
+    Optional<LeagueOrganizer> findByLeague_IdAndUserId(UUID leagueId, String userId);
+
+    boolean existsByLeague_IdAndUserId(UUID leagueId, String userId);
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerRepository.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/repository/LeagueOrganizerRepository.java
@@ -14,4 +14,6 @@ public interface LeagueOrganizerRepository extends JpaRepository<LeagueOrganizer
     Optional<LeagueOrganizer> findByLeague_IdAndUserId(UUID leagueId, String userId);
 
     boolean existsByLeague_IdAndUserId(UUID leagueId, String userId);
+
+    List<LeagueOrganizer> findByUserId(String userId);
 }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueInviteService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueInviteService.java
@@ -16,6 +16,7 @@ import com.game.on.go_league_service.league.model.League;
 import com.game.on.go_league_service.league.model.LeagueTeam;
 import com.game.on.go_league_service.league.model.LeagueTeamInvite;
 import com.game.on.go_league_service.league.model.LeagueTeamInviteStatus;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerRepository;
 import com.game.on.go_league_service.league.repository.LeagueRepository;
 import com.game.on.go_league_service.league.repository.LeagueTeamInviteRepository;
 import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
@@ -37,6 +38,7 @@ public class LeagueInviteService {
 
     private static final Set<String> TEAM_ADMIN_ROLES = Set.of("OWNER", "MANAGER");
 
+    private final LeagueOrganizerRepository organizerRepository;
     private final LeagueRepository leagueRepository;
     private final LeagueTeamRepository leagueTeamRepository;
     private final LeagueTeamInviteRepository leagueTeamInviteRepository;
@@ -146,7 +148,8 @@ public class LeagueInviteService {
     }
 
     private void ensureLeagueOwner(League league, String userId) {
-        if (!league.getOwnerUserId().equals(userId)) {
+        if (!league.getOwnerUserId().equals(userId)
+                && !organizerRepository.existsByLeague_IdAndUserId(league.getId(), userId)) {
             throw new ForbiddenException("Only the league owner can invite teams");
         }
     }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueMatchService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueMatchService.java
@@ -14,11 +14,7 @@ import com.game.on.go_league_service.league.model.LeagueMatchScore;
 import com.game.on.go_league_service.league.model.LeagueMatchStatus;
 import com.game.on.go_league_service.league.model.RefereeProfile;
 import com.game.on.go_league_service.league.model.Venue;
-import com.game.on.go_league_service.league.repository.LeagueMatchRepository;
-import com.game.on.go_league_service.league.repository.LeagueMatchScoreRepository;
-import com.game.on.go_league_service.league.repository.LeagueRepository;
-import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
-import com.game.on.go_league_service.league.repository.RefereeProfileRepository;
+import com.game.on.go_league_service.league.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,6 +35,8 @@ public class LeagueMatchService {
     private static final String LEAGUE_TEAM_SAME_DAY_CONFLICT_CODE = "LEAGUE_TEAM_SAME_DAY_CONFLICT";
     private static final String LEAGUE_TEAM_SAME_DAY_CONFLICT_MESSAGE =
             "One of these teams already has a confirmed match on this day. League teams are limited to one match per day.";
+
+    private final LeagueOrganizerRepository organizerRepository;
 
     private final LeagueRepository leagueRepository;
     private final LeagueTeamRepository leagueTeamRepository;
@@ -359,7 +357,8 @@ public class LeagueMatchService {
     }
 
     private void ensureLeagueOwner(League league, String userId) {
-        if (!league.getOwnerUserId().equals(userId)) {
+        if (!league.getOwnerUserId().equals(userId)
+                && !organizerRepository.existsByLeague_IdAndUserId(league.getId(), userId)) {
             throw new ForbiddenException("Only the league owner can perform this action");
         }
     }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueOrganizerService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueOrganizerService.java
@@ -1,0 +1,169 @@
+package com.game.on.go_league_service.league.service;
+
+import com.game.on.go_league_service.config.CurrentUserProvider;
+import com.game.on.go_league_service.exception.ConflictException;
+import com.game.on.go_league_service.exception.ForbiddenException;
+import com.game.on.go_league_service.exception.NotFoundException;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerInviteCreateRequest;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerResponse;
+import com.game.on.go_league_service.league.model.*;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerInviteRepository;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerRepository;
+import com.game.on.go_league_service.league.repository.LeagueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LeagueOrganizerService {
+
+    private final LeagueRepository leagueRepository;
+    private final LeagueOrganizerRepository organizerRepository;
+    private final LeagueOrganizerInviteRepository inviteRepository;
+    private final CurrentUserProvider userProvider;
+
+    @Transactional
+    public void createInvite(UUID leagueId, LeagueOrganizerInviteCreateRequest request) {
+        String userId = userProvider.clerkUserId();
+        League league = requireActiveLeague(leagueId);
+        ensureOwnerOrOrganizer(league, userId);
+
+        String inviteeId = request.inviteeUserId();
+
+        if (inviteeId.equals(league.getOwnerUserId())) {
+            throw new ConflictException("The league owner cannot be invited as an organizer");
+        }
+        if (organizerRepository.existsByLeague_IdAndUserId(leagueId, inviteeId)) {
+            throw new ConflictException("User is already an organizer");
+        }
+        inviteRepository.findByLeague_IdAndInviteeUserIdAndStatus(
+                leagueId, inviteeId, LeagueOrganizerInviteStatus.PENDING
+        ).ifPresent(e -> {
+            throw new ConflictException("A pending invite already exists for this user");
+        });
+
+        inviteRepository.save(LeagueOrganizerInvite.builder()
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(userId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build());
+
+        log.info("league_organizer_invite_created league={} invitee={} by={}",
+                leagueId, inviteeId, userId);
+    }
+
+    @Transactional
+    public void acceptInvite(UUID inviteId) {
+        String userId = userProvider.clerkUserId();
+        var invite = inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING)
+                .orElseThrow(() -> new NotFoundException("Invite not found or already handled"));
+
+        if (!invite.getInviteeUserId().equals(userId)) {
+            throw new ForbiddenException("You can only accept your own invites");
+        }
+
+        UUID leagueId = invite.getLeague().getId();
+        if (organizerRepository.existsByLeague_IdAndUserId(leagueId, userId)) {
+            throw new ConflictException("Already an organizer of this league");
+        }
+
+        organizerRepository.save(LeagueOrganizer.builder()
+                .league(invite.getLeague())
+                .userId(userId)
+                .build());
+
+        invite.setStatus(LeagueOrganizerInviteStatus.ACCEPTED);
+        invite.setRespondedAt(OffsetDateTime.now());
+        inviteRepository.save(invite);
+
+        log.info("league_organizer_invite_accepted invite={} league={} user={}",
+                inviteId, leagueId, userId);
+    }
+
+    @Transactional
+    public void declineInvite(UUID inviteId) {
+        String userId = userProvider.clerkUserId();
+        var invite = inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING)
+                .orElseThrow(() -> new NotFoundException("Invite not found or already handled"));
+
+        if (!invite.getInviteeUserId().equals(userId)) {
+            throw new ForbiddenException("You can only decline your own invites");
+        }
+
+        invite.setStatus(LeagueOrganizerInviteStatus.DECLINED);
+        invite.setRespondedAt(OffsetDateTime.now());
+        inviteRepository.save(invite);
+
+        log.info("league_organizer_invite_declined invite={} league={} user={}",
+                inviteId, invite.getLeague().getId(), userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LeagueOrganizerResponse> listOrganizers(UUID leagueId) {
+        requireActiveLeague(leagueId);
+        return organizerRepository.findByLeague_IdOrderByJoinedAtAsc(leagueId)
+                .stream()
+                .map(o -> new LeagueOrganizerResponse(
+                        o.getId(), o.getLeague().getId(),
+                        o.getUserId(), o.getJoinedAt()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> listPendingInviteeIds(UUID leagueId) {
+        String userId = userProvider.clerkUserId();
+        League league = requireActiveLeague(leagueId);
+        ensureOwnerOrOrganizer(league, userId);
+        return inviteRepository
+                .findByLeague_IdAndStatusOrderByCreatedAtDesc(leagueId, LeagueOrganizerInviteStatus.PENDING)
+                .stream()
+                .map(LeagueOrganizerInvite::getInviteeUserId)
+                .toList();
+    }
+
+    @Transactional
+    public void removeOrganizer(UUID leagueId, String targetUserId) {
+        String userId = userProvider.clerkUserId();
+        League league = requireActiveLeague(leagueId);
+
+        if (!league.getOwnerUserId().equals(userId)) {
+            throw new ForbiddenException("Only the league owner can remove organizers");
+        }
+
+        var organizer = organizerRepository.findByLeague_IdAndUserId(leagueId, targetUserId)
+                .orElseThrow(() -> new NotFoundException("Organizer not found"));
+
+        organizerRepository.delete(organizer);
+        log.info("league_organizer_removed league={} target={} by={}",
+                leagueId, targetUserId, userId);
+    }
+
+    /**
+     * Returns true if userId is either the league owner or an active organizer.
+     * This is the method that other services should call to replace their
+     * owner-only checks when organizers should also be allowed.
+     */
+    public boolean isOwnerOrOrganizer(League league, String userId) {
+        if (league.getOwnerUserId().equals(userId)) return true;
+        return organizerRepository.existsByLeague_IdAndUserId(league.getId(), userId);
+    }
+
+    public void ensureOwnerOrOrganizer(League league, String userId) {
+        if (!isOwnerOrOrganizer(league, userId)) {
+            throw new ForbiddenException("Only the league owner or organizers can perform this action");
+        }
+    }
+
+    private League requireActiveLeague(UUID leagueId) {
+        return leagueRepository.findByIdAndArchivedAtIsNull(leagueId)
+                .orElseThrow(() -> new NotFoundException("League not found"));
+    }
+}

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueOrganizerService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueOrganizerService.java
@@ -5,6 +5,7 @@ import com.game.on.go_league_service.exception.ConflictException;
 import com.game.on.go_league_service.exception.ForbiddenException;
 import com.game.on.go_league_service.exception.NotFoundException;
 import com.game.on.go_league_service.league.dto.LeagueOrganizerInviteCreateRequest;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerInviteResponse;
 import com.game.on.go_league_service.league.dto.LeagueOrganizerResponse;
 import com.game.on.go_league_service.league.model.*;
 import com.game.on.go_league_service.league.repository.LeagueOrganizerInviteRepository;
@@ -160,6 +161,22 @@ public class LeagueOrganizerService {
         if (!isOwnerOrOrganizer(league, userId)) {
             throw new ForbiddenException("Only the league owner or organizers can perform this action");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<LeagueOrganizerInviteResponse> listMyPendingInvites() {
+        String userId = userProvider.clerkUserId();
+        return inviteRepository.findByInviteeUserIdAndStatusOrderByCreatedAtDesc(userId, LeagueOrganizerInviteStatus.PENDING)
+                .stream()
+                .map(i -> new LeagueOrganizerInviteResponse(
+                        i.getId(),
+                        i.getLeague().getId(),
+                        i.getInviteeUserId(),
+                        i.getInvitedByUserId(),
+                        i.getStatus().name(),
+                        i.getCreatedAt(),
+                        i.getRespondedAt()))
+                .toList();
     }
 
     private League requireActiveLeague(UUID leagueId) {

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueService.java
@@ -15,6 +15,7 @@ import com.game.on.go_league_service.league.mapper.LeagueTeamMapper;
 import com.game.on.go_league_service.league.repository.*;
 import com.game.on.go_league_service.league.repository.LeagueSeasonRepository.LeagueSeasonCountProjection;
 import com.game.on.go_league_service.league.util.SlugGenerator;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -42,6 +43,7 @@ import static com.game.on.go_league_service.league.service.LeagueSpecifications.
 @RequiredArgsConstructor
 public class LeagueService {
 
+    private final LeagueOrganizerRepository organizerRepository;
     private final LeagueRepository leagueRepository;
     private final LeagueSeasonRepository leagueSeasonRepository;
     private final LeagueMapper leagueMapper;
@@ -385,14 +387,16 @@ public class LeagueService {
     }
 
     private void ensureOwner(League league, String callerId) {
-        if (!league.getOwnerUserId().equals(callerId)) {
+        if (!league.getOwnerUserId().equals(callerId)
+                && !organizerRepository.existsByLeague_IdAndUserId(league.getId(), callerId)) {
             throw new ForbiddenException("Only the owner can perform this action");
         }
     }
 
     public void ensureCanView(League league, String callerId) {
         if (league.getPrivacy() == LeaguePrivacy.PRIVATE
-                && !league.getOwnerUserId().equals(callerId)) {
+                && !league.getOwnerUserId().equals(callerId)
+                && !organizerRepository.existsByLeague_IdAndUserId(league.getId(), callerId)) {
             throw new NotFoundException("League not found");
         }
     }

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league/service/LeagueService.java
@@ -160,7 +160,13 @@ public class LeagueService {
             var leagueIds = teamIds.isEmpty()
                     ? List.<UUID>of()
                     : leagueTeamRepository.findLeagueIdsByTeamIdIn(teamIds);
-            var mineSpec = ownerIs(userId).or(idIn(leagueIds));
+            var organizerLeagueIds = organizerRepository.findByUserId(userId)
+                    .stream()
+                    .map(o -> o.getLeague().getId())
+                    .toList();
+            var allLeagueIds = new java.util.ArrayList<>(leagueIds);
+            allLeagueIds.addAll(organizerLeagueIds);
+            var mineSpec = ownerIs(userId).or(idIn(allLeagueIds));
             spec = and(spec, mineSpec);
         } else {
             spec = and(spec, visibleTo(userId));

--- a/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/service/LeaguePostService.java
+++ b/Backend/go-league-service/src/main/java/com/game/on/go_league_service/league_post/service/LeaguePostService.java
@@ -4,6 +4,7 @@ import com.game.on.go_league_service.config.CurrentUserProvider;
 import com.game.on.go_league_service.exception.ForbiddenException;
 import com.game.on.go_league_service.exception.NotFoundException;
 import com.game.on.go_league_service.league.model.League;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerRepository;
 import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
 import com.game.on.go_league_service.league.service.LeagueService;
 import com.game.on.go_league_service.league_post.dto.*;
@@ -26,6 +27,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class LeaguePostService {
 
+    private final LeagueOrganizerRepository organizerRepository;
     private final LeaguePostRepository postRepository;
     private final LeagueService leagueService;
     private final LeagueTeamRepository leagueTeamRepository;
@@ -115,8 +117,9 @@ public class LeaguePostService {
     }
 
     private void ensureOwner(League league, String userId) {
-        if (!league.getOwnerUserId().equals(userId)) {
-            throw new ForbiddenException("Only the owner can perform this action");
+        if (!league.getOwnerUserId().equals(userId)
+                && !organizerRepository.existsByLeague_IdAndUserId(league.getId(), userId)) {
+            throw new ForbiddenException("Only the league owner can perform this action");
         }
     }
 

--- a/Backend/go-league-service/src/main/resources/db/migration/V12__create_league_organizers.sql
+++ b/Backend/go-league-service/src/main/resources/db/migration/V12__create_league_organizers.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS league_organizers (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    league_id  UUID         NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    user_id    VARCHAR(255) NOT NULL,
+    joined_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uq_league_organizer UNIQUE (league_id, user_id)
+);
+
+CREATE INDEX idx_league_organizers_league ON league_organizers(league_id);
+CREATE INDEX idx_league_organizers_user   ON league_organizers(user_id);
+
+CREATE TABLE IF NOT EXISTS league_organizer_invites (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    league_id           UUID         NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+    invitee_user_id     VARCHAR(255) NOT NULL,
+    invited_by_user_id  VARCHAR(255) NOT NULL,
+    status              VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    responded_at        TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_org_invites_league  ON league_organizer_invites(league_id);
+CREATE INDEX idx_org_invites_invitee ON league_organizer_invites(invitee_user_id);

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueOrganizerServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueOrganizerServiceTest.java
@@ -1,0 +1,405 @@
+package com.game.on.go_league_service.league;
+
+import com.game.on.go_league_service.config.CurrentUserProvider;
+import com.game.on.go_league_service.exception.ConflictException;
+import com.game.on.go_league_service.exception.ForbiddenException;
+import com.game.on.go_league_service.exception.NotFoundException;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerInviteCreateRequest;
+import com.game.on.go_league_service.league.dto.LeagueOrganizerResponse;
+import com.game.on.go_league_service.league.model.League;
+import com.game.on.go_league_service.league.model.LeagueOrganizer;
+import com.game.on.go_league_service.league.model.LeagueOrganizerInvite;
+import com.game.on.go_league_service.league.model.LeagueOrganizerInviteStatus;
+import com.game.on.go_league_service.league.model.LeaguePrivacy;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerInviteRepository;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerRepository;
+import com.game.on.go_league_service.league.repository.LeagueRepository;
+import com.game.on.go_league_service.league.service.LeagueOrganizerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LeagueOrganizerServiceTest {
+
+    @Mock private LeagueRepository leagueRepository;
+    @Mock private LeagueOrganizerRepository organizerRepository;
+    @Mock private LeagueOrganizerInviteRepository inviteRepository;
+    @Mock private CurrentUserProvider userProvider;
+
+    @InjectMocks private LeagueOrganizerService service;
+
+    private UUID leagueId;
+    private League league;
+    private final String ownerId = "owner_user";
+    private final String organizerId = "organizer_user";
+    private final String inviteeId = "invitee_user";
+    private final String outsiderId = "outsider_user";
+
+    @BeforeEach
+    void setUp() {
+        leagueId = UUID.randomUUID();
+        league = League.builder()
+                .id(leagueId)
+                .name("Test League")
+                .sport("soccer")
+                .slug("test-league")
+                .ownerUserId(ownerId)
+                .privacy(LeaguePrivacy.PUBLIC)
+                .seasonCount(0)
+                .build();
+    }
+
+    // ── createInvite ────────────────────────────────────────────
+
+    @Test
+    void owner_can_create_organizer_invite() {
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, inviteeId)).thenReturn(false);
+        when(inviteRepository.findByLeague_IdAndInviteeUserIdAndStatus(leagueId, inviteeId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.empty());
+        when(inviteRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.createInvite(leagueId, new LeagueOrganizerInviteCreateRequest(inviteeId));
+
+        ArgumentCaptor<LeagueOrganizerInvite> captor = ArgumentCaptor.forClass(LeagueOrganizerInvite.class);
+        verify(inviteRepository).save(captor.capture());
+
+        LeagueOrganizerInvite saved = captor.getValue();
+        assertThat(saved.getInviteeUserId()).isEqualTo(inviteeId);
+        assertThat(saved.getInvitedByUserId()).isEqualTo(ownerId);
+        assertThat(saved.getStatus()).isEqualTo(LeagueOrganizerInviteStatus.PENDING);
+    }
+
+    @Test
+    void cannot_invite_the_league_owner_as_organizer() {
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+
+        assertThatThrownBy(() ->
+                service.createInvite(leagueId, new LeagueOrganizerInviteCreateRequest(ownerId))
+        ).isInstanceOf(ConflictException.class);
+
+        verify(inviteRepository, never()).save(any());
+    }
+
+    @Test
+    void cannot_invite_existing_organizer() {
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, inviteeId)).thenReturn(true);
+
+        assertThatThrownBy(() ->
+                service.createInvite(leagueId, new LeagueOrganizerInviteCreateRequest(inviteeId))
+        ).isInstanceOf(ConflictException.class);
+
+        verify(inviteRepository, never()).save(any());
+    }
+
+    @Test
+    void cannot_create_duplicate_pending_invite() {
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, inviteeId)).thenReturn(false);
+        when(inviteRepository.findByLeague_IdAndInviteeUserIdAndStatus(leagueId, inviteeId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.of(LeagueOrganizerInvite.builder().build()));
+
+        assertThatThrownBy(() ->
+                service.createInvite(leagueId, new LeagueOrganizerInviteCreateRequest(inviteeId))
+        ).isInstanceOf(ConflictException.class);
+
+        verify(inviteRepository, never()).save(any());
+    }
+
+    @Test
+    void outsider_cannot_create_invite() {
+        when(userProvider.clerkUserId()).thenReturn(outsiderId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, outsiderId)).thenReturn(false);
+
+        assertThatThrownBy(() ->
+                service.createInvite(leagueId, new LeagueOrganizerInviteCreateRequest(inviteeId))
+        ).isInstanceOf(ForbiddenException.class);
+
+        verify(inviteRepository, never()).save(any());
+    }
+
+    // ── acceptInvite ────────────────────────────────────────────
+
+    @Test
+    void invitee_can_accept_invite() {
+        UUID inviteId = UUID.randomUUID();
+        LeagueOrganizerInvite invite = LeagueOrganizerInvite.builder()
+                .id(inviteId)
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(ownerId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(inviteeId);
+        when(inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.of(invite));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, inviteeId)).thenReturn(false);
+        when(organizerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(inviteRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.acceptInvite(inviteId);
+
+        ArgumentCaptor<LeagueOrganizer> orgCaptor = ArgumentCaptor.forClass(LeagueOrganizer.class);
+        verify(organizerRepository).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getUserId()).isEqualTo(inviteeId);
+        assertThat(orgCaptor.getValue().getLeague().getId()).isEqualTo(leagueId);
+
+        assertThat(invite.getStatus()).isEqualTo(LeagueOrganizerInviteStatus.ACCEPTED);
+        assertThat(invite.getRespondedAt()).isNotNull();
+    }
+
+    @Test
+    void non_invitee_cannot_accept_invite() {
+        UUID inviteId = UUID.randomUUID();
+        LeagueOrganizerInvite invite = LeagueOrganizerInvite.builder()
+                .id(inviteId)
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(ownerId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(outsiderId);
+        when(inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.of(invite));
+
+        assertThatThrownBy(() -> service.acceptInvite(inviteId))
+                .isInstanceOf(ForbiddenException.class);
+
+        verify(organizerRepository, never()).save(any());
+    }
+
+    @Test
+    void accept_throws_not_found_for_missing_invite() {
+        UUID inviteId = UUID.randomUUID();
+        when(userProvider.clerkUserId()).thenReturn(inviteeId);
+        when(inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.acceptInvite(inviteId))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void accept_throws_conflict_if_already_organizer() {
+        UUID inviteId = UUID.randomUUID();
+        LeagueOrganizerInvite invite = LeagueOrganizerInvite.builder()
+                .id(inviteId)
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(ownerId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(inviteeId);
+        when(inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.of(invite));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, inviteeId)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.acceptInvite(inviteId))
+                .isInstanceOf(ConflictException.class);
+
+        verify(organizerRepository, never()).save(any());
+    }
+
+    // ── declineInvite ───────────────────────────────────────────
+
+    @Test
+    void invitee_can_decline_invite() {
+        UUID inviteId = UUID.randomUUID();
+        LeagueOrganizerInvite invite = LeagueOrganizerInvite.builder()
+                .id(inviteId)
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(ownerId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(inviteeId);
+        when(inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.of(invite));
+        when(inviteRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.declineInvite(inviteId);
+
+        assertThat(invite.getStatus()).isEqualTo(LeagueOrganizerInviteStatus.DECLINED);
+        assertThat(invite.getRespondedAt()).isNotNull();
+        verify(organizerRepository, never()).save(any());
+    }
+
+    @Test
+    void non_invitee_cannot_decline_invite() {
+        UUID inviteId = UUID.randomUUID();
+        LeagueOrganizerInvite invite = LeagueOrganizerInvite.builder()
+                .id(inviteId)
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(ownerId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(outsiderId);
+        when(inviteRepository.findByIdAndStatus(inviteId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(Optional.of(invite));
+
+        assertThatThrownBy(() -> service.declineInvite(inviteId))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    // ── removeOrganizer ─────────────────────────────────────────
+
+    @Test
+    void owner_can_remove_organizer() {
+        LeagueOrganizer organizer = LeagueOrganizer.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .userId(organizerId)
+                .joinedAt(OffsetDateTime.now())
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.findByLeague_IdAndUserId(leagueId, organizerId))
+                .thenReturn(Optional.of(organizer));
+
+        service.removeOrganizer(leagueId, organizerId);
+
+        verify(organizerRepository).delete(organizer);
+    }
+
+    @Test
+    void non_owner_cannot_remove_organizer() {
+        when(userProvider.clerkUserId()).thenReturn(organizerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+
+        assertThatThrownBy(() -> service.removeOrganizer(leagueId, inviteeId))
+                .isInstanceOf(ForbiddenException.class);
+
+        verify(organizerRepository, never()).delete(any());
+    }
+
+    @Test
+    void remove_throws_not_found_for_missing_organizer() {
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.findByLeague_IdAndUserId(leagueId, inviteeId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.removeOrganizer(leagueId, inviteeId))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── listOrganizers ──────────────────────────────────────────
+
+    @Test
+    void list_organizers_returns_mapped_responses() {
+        LeagueOrganizer org1 = LeagueOrganizer.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .userId(organizerId)
+                .joinedAt(OffsetDateTime.now())
+                .build();
+
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.findByLeague_IdOrderByJoinedAtAsc(leagueId))
+                .thenReturn(List.of(org1));
+
+        List<LeagueOrganizerResponse> result = service.listOrganizers(leagueId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).userId()).isEqualTo(organizerId);
+        assertThat(result.get(0).leagueId()).isEqualTo(leagueId);
+    }
+
+    @Test
+    void list_organizers_throws_not_found_for_archived_league() {
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.listOrganizers(leagueId))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── listPendingInviteeIds ───────────────────────────────────
+
+    @Test
+    void list_pending_invitee_ids_returns_user_ids() {
+        LeagueOrganizerInvite inv1 = LeagueOrganizerInvite.builder()
+                .id(UUID.randomUUID())
+                .league(league)
+                .inviteeUserId(inviteeId)
+                .invitedByUserId(ownerId)
+                .status(LeagueOrganizerInviteStatus.PENDING)
+                .build();
+
+        when(userProvider.clerkUserId()).thenReturn(ownerId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(inviteRepository.findByLeague_IdAndStatusOrderByCreatedAtDesc(leagueId, LeagueOrganizerInviteStatus.PENDING))
+                .thenReturn(List.of(inv1));
+
+        List<String> result = service.listPendingInviteeIds(leagueId);
+
+        assertThat(result).containsExactly(inviteeId);
+    }
+
+    @Test
+    void list_pending_invitee_ids_rejects_outsider() {
+        when(userProvider.clerkUserId()).thenReturn(outsiderId);
+        when(leagueRepository.findByIdAndArchivedAtIsNull(leagueId)).thenReturn(Optional.of(league));
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, outsiderId)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.listPendingInviteeIds(leagueId))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    // ── isOwnerOrOrganizer ──────────────────────────────────────
+
+    @Test
+    void isOwnerOrOrganizer_returns_true_for_owner() {
+        assertThat(service.isOwnerOrOrganizer(league, ownerId)).isTrue();
+        verify(organizerRepository, never()).existsByLeague_IdAndUserId(any(), any());
+    }
+
+    @Test
+    void isOwnerOrOrganizer_returns_true_for_organizer() {
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, organizerId)).thenReturn(true);
+
+        assertThat(service.isOwnerOrOrganizer(league, organizerId)).isTrue();
+    }
+
+    @Test
+    void isOwnerOrOrganizer_returns_false_for_outsider() {
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, outsiderId)).thenReturn(false);
+
+        assertThat(service.isOwnerOrOrganizer(league, outsiderId)).isFalse();
+    }
+
+    @Test
+    void ensureOwnerOrOrganizer_throws_for_outsider() {
+        when(organizerRepository.existsByLeague_IdAndUserId(leagueId, outsiderId)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.ensureOwnerOrOrganizer(league, outsiderId))
+                .isInstanceOf(ForbiddenException.class);
+    }
+}

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league/LeagueServiceTest.java
@@ -73,12 +73,16 @@ class LeagueServiceTest {
     @Mock
     private LeagueMatchScoreRepository leagueMatchScoreRepository;
 
+    @Mock
+    private LeagueOrganizerRepository organizerRepository;
+
     private LeagueService leagueService;
 
     @BeforeEach
     void setUp() {
         LeagueMapper mapper = new LeagueMapper(slugGenerator);
         leagueService = new LeagueService(
+                organizerRepository,
                 leagueRepository,
                 leagueSeasonRepository,
                 mapper,

--- a/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league_post/service/LeaguePostServiceTest.java
+++ b/Backend/go-league-service/src/test/java/com/game/on/go_league_service/league_post/service/LeaguePostServiceTest.java
@@ -4,6 +4,7 @@ import com.game.on.go_league_service.config.CurrentUserProvider;
 import com.game.on.go_league_service.exception.ForbiddenException;
 import com.game.on.go_league_service.exception.NotFoundException;
 import com.game.on.go_league_service.league.model.League;
+import com.game.on.go_league_service.league.repository.LeagueOrganizerRepository;
 import com.game.on.go_league_service.league.repository.LeagueTeamRepository;
 import com.game.on.go_league_service.league.service.LeagueService;
 import com.game.on.go_league_service.league_post.dto.LeaguePostCreateRequest;
@@ -41,6 +42,7 @@ class LeaguePostServiceTest {
     @Mock private LeaguePostRepository postRepository;
     @Mock private LeagueService leagueService;
     @Mock private LeagueTeamRepository leagueTeamRepository;
+    @Mock private LeagueOrganizerRepository organizerRepository;
     @Mock private CurrentUserProvider userProvider;
     @Mock private LeaguePostMapper mapper;
 

--- a/Frontend/__tests__/utils/notifications.test.ts
+++ b/Frontend/__tests__/utils/notifications.test.ts
@@ -8,7 +8,10 @@ import {
 } from "@/hooks/use-axios-clerk";
 import { NotificationItem, TeamInviteCard } from "@/types/notifications";
 import * as notificationsUtils from "@/utils/notifications";
-import { fetchLeagueInvitesWithDetails } from "@/utils/leagues";
+import {
+  fetchLeagueInvitesWithDetails,
+  fetchOrganizerInvitesWithDetails,
+} from "@/utils/leagues";
 import {
   fetchIncomingRefereeInvites,
   fetchIncomingTeamMatchInvites,
@@ -17,6 +20,10 @@ import {
 const mockFetchLeagueInvitesWithDetails =
   fetchLeagueInvitesWithDetails as jest.MockedFunction<
     typeof fetchLeagueInvitesWithDetails
+  >;
+const mockFetchOrganizerInvitesWithDetails =
+  fetchOrganizerInvitesWithDetails as jest.MockedFunction<
+    typeof fetchOrganizerInvitesWithDetails
   >;
 const mockFetchIncomingTeamMatchInvites =
   fetchIncomingTeamMatchInvites as jest.MockedFunction<
@@ -35,6 +42,7 @@ function asAxiosInstance(api: {
 
 jest.mock("@/utils/leagues", () => ({
   fetchLeagueInvitesWithDetails: jest.fn(),
+  fetchOrganizerInvitesWithDetails: jest.fn(),
 }));
 
 jest.mock("@/hooks/use-matches", () => ({
@@ -289,6 +297,7 @@ describe("notification utilities", () => {
         leaguePrivacy: LeaguePrivacy.PRIVATE,
       },
     ]);
+    mockFetchOrganizerInvitesWithDetails.mockResolvedValue([]);
     mockFetchIncomingTeamMatchInvites.mockResolvedValue([
       {
         kind: "team-match",
@@ -338,6 +347,7 @@ describe("notification utilities", () => {
       new Error("team source unavailable"),
     );
     mockFetchLeagueInvitesWithDetails.mockResolvedValue([]);
+    mockFetchOrganizerInvitesWithDetails.mockResolvedValue([]);
     mockFetchIncomingTeamMatchInvites.mockResolvedValue([]);
     mockFetchIncomingRefereeInvites.mockResolvedValue([
       {
@@ -372,6 +382,7 @@ describe("notification utilities", () => {
     });
 
     mockFetchLeagueInvitesWithDetails.mockResolvedValue([]);
+    mockFetchOrganizerInvitesWithDetails.mockResolvedValue([]);
     mockFetchIncomingTeamMatchInvites.mockRejectedValue(
       new Error("team matches unavailable"),
     );
@@ -416,6 +427,7 @@ describe("notification utilities", () => {
     mockFetchLeagueInvitesWithDetails.mockRejectedValue(
       new Error("league source unavailable"),
     );
+    mockFetchOrganizerInvitesWithDetails.mockResolvedValue([]);
     mockFetchIncomingTeamMatchInvites.mockResolvedValue([]);
     mockFetchIncomingRefereeInvites.mockRejectedValue(
       new Error("referee source unavailable"),

--- a/Frontend/app/(app)/leagues/[id]/index.tsx
+++ b/Frontend/app/(app)/leagues/[id]/index.tsx
@@ -50,6 +50,7 @@ function LeagueToolbar({
   id,
   isMember,
   isOwner,
+  isOrganizer,
   onFollow,
   openPost,
   openSchedule,
@@ -58,6 +59,7 @@ function LeagueToolbar({
   id: string;
   isMember: boolean;
   isOwner: boolean;
+  isOrganizer: boolean;
   onFollow: () => void;
   openPost?: () => void;
   openSchedule?: () => void;
@@ -67,7 +69,7 @@ function LeagueToolbar({
   return (
     <>
       <Stack.Screen.Title>{title}</Stack.Screen.Title>
-      {isMember || isOwner ? (
+      {isMember || isOwner || isOrganizer ? (
         <Stack.Toolbar placement="right">
           <Stack.Toolbar.Button
             icon="gear"
@@ -132,11 +134,15 @@ function LeagueContent() {
     title,
     isMember,
     isOwner,
+    isOrganizer,
     league,
     leagueTeams,
     isLeagueTeamsLoading,
     leagueTeamsError,
   } = useLeagueDetailContext();
+
+  const canManage = isOwner || isOrganizer;
+
   const {
     data: standings = [],
     isLoading: standingsLoading,
@@ -245,9 +251,10 @@ function LeagueContent() {
             id={id}
             isMember={isMember}
             isOwner={isOwner}
+            isOrganizer={isOrganizer}
             onFollow={handleFollow}
-            openPost={isOwner ? openPost : undefined}
-            openSchedule={isOwner ? openSchedule : undefined}
+            openPost={canManage ? openPost : undefined}
+            openSchedule={canManage ? openSchedule : undefined}
           />
         }
         background={{ preset: "red" }}
@@ -272,7 +279,7 @@ function LeagueContent() {
                     : getSportLogo(league?.sport)
                 }
                 onDeletePost={handleDeletePost}
-                canDelete={isOwner}
+                canDelete={canManage}
               />
             )}
 

--- a/Frontend/app/(app)/leagues/[id]/settings/index.tsx
+++ b/Frontend/app/(app)/leagues/[id]/settings/index.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, ReactNode } from "react";
-import { Pressable } from "react-native";
+import { Alert, Pressable } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useNavigation, StackActions } from "@react-navigation/native";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useActionSheet } from "@expo/react-native-action-sheet";
 import ContextMenu from "react-native-context-menu-view";
 import { toast } from "@/utils/toast";
@@ -10,6 +10,7 @@ import { ContentArea } from "@/components/ui/content-area";
 import { Empty } from "@/components/ui/empty";
 import { Form } from "@/components/form/form";
 import { AccentColors } from "@/constants/colors";
+import { images } from "@/constants/images";
 import { createScopedLog } from "@/utils/logger";
 import { errorToString } from "@/utils/error";
 import { usePayment, type PaymentEntityType } from "@/hooks/use-payment";
@@ -38,6 +39,7 @@ import {
   useLeagueDetailContext,
 } from "@/contexts/league-detail-context";
 import { Loading } from "@/components/ui/loading";
+import { fetchUserDirectory } from "@/hooks/messages/api";
 
 const log = createScopedLog("League Settings");
 
@@ -67,6 +69,7 @@ function LeagueSettingsContent() {
     league,
     isLoading: leagueLoading,
     isOwner,
+    isOrganizer,
     leagueTeams,
   } = useLeagueDetailContext();
 
@@ -111,6 +114,7 @@ function LeagueSettingsContent() {
       });
     },
   });
+
   const removeTeamMutation = useMutation({
     mutationFn: async (teamId: string) => {
       await api.delete(GO_LEAGUE_SERVICE_ROUTES.REMOVE_TEAM(id, teamId));
@@ -128,7 +132,53 @@ function LeagueSettingsContent() {
     },
   });
 
-  if (!isOwner) {
+  // ── Organizers ──────────────────────────────────────────────
+  const organizersQuery = useQuery<
+    { id: string; userId: string; joinedAt: string }[]
+  >({
+    queryKey: ["league-organizers", id],
+    queryFn: async () => {
+      const resp = await api.get(GO_LEAGUE_SERVICE_ROUTES.ORGANIZERS(id));
+      return resp.data ?? [];
+    },
+    enabled: Boolean(id),
+  });
+
+  const { data: userDirectory = [] } = useQuery({
+    queryKey: ["user-directory"],
+    queryFn: async () => fetchUserDirectory(api),
+    enabled: Boolean(id && (isOwner || isOrganizer)),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const removeOrganizerMutation = useMutation({
+    mutationFn: async (organizerUserId: string) => {
+      await api.delete(
+        GO_LEAGUE_SERVICE_ROUTES.REMOVE_ORGANIZER(id, organizerUserId),
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["league-organizers", id],
+      });
+    },
+    onError: (err) => {
+      toast.error("Remove Failed", { description: errorToString(err) });
+    },
+  });
+
+  const handleRemoveOrganizer = (organizerUserId: string, name: string) => {
+    Alert.alert("Remove Organizer", `Remove ${name} from league organizers?`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Remove",
+        style: "destructive",
+        onPress: () => removeOrganizerMutation.mutate(organizerUserId),
+      },
+    ]);
+  };
+
+  if (!isOwner && !isOrganizer) {
     return (
       <ContentArea background={{ preset: "red" }}>
         <Empty message="You don't have permission to edit this league" />
@@ -205,6 +255,41 @@ function LeagueSettingsContent() {
           <Form.Button
             button="Invite Teams"
             onPress={() => router.push(`/leagues/${id}/settings/invite`)}
+          />
+        </Form.Section>
+
+        <Form.Section header="Organizers">
+          {(organizersQuery.data ?? []).map((organizer) => {
+            const user = userDirectory.find((u) => u.id === organizer.userId);
+            const name = user
+              ? `${user.firstname ?? ""} ${user.lastname ?? ""}`.trim() ||
+                user.email
+              : organizer.userId;
+            return (
+              <OrganizerMenu
+                key={organizer.id}
+                canRemove={isOwner && !removeOrganizerMutation.isPending}
+                onRemove={() =>
+                  handleRemoveOrganizer(organizer.userId, name)
+                }
+              >
+                <MenuCardItem
+                  title={name}
+                  subtitle={formatMemberSince(organizer.joinedAt)}
+                  image={
+                    user?.imageUrl
+                      ? { uri: user.imageUrl }
+                      : images.defaultProfile
+                  }
+                />
+              </OrganizerMenu>
+            );
+          })}
+          <Form.Button
+            button="Invite Organizers"
+            onPress={() =>
+              router.push(`/leagues/${id}/settings/invite-organizers`)
+            }
           />
         </Form.Section>
 
@@ -301,6 +386,36 @@ function LeagueTeamMenu({
         if (event.nativeEvent.name === "Remove Team") {
           onDelete();
         }
+      }}
+      previewBackgroundColor="transparent"
+    >
+      {children}
+    </ContextMenu>
+  );
+}
+
+function OrganizerMenu({
+  onRemove,
+  canRemove,
+  children,
+}: Readonly<{
+  onRemove: () => void;
+  canRemove: boolean;
+  children: ReactNode;
+}>) {
+  if (!canRemove) return children;
+
+  if (isRunningInExpoGo) {
+    return <Pressable onLongPress={onRemove}>{children}</Pressable>;
+  }
+
+  return (
+    <ContextMenu
+      actions={[
+        { title: "Remove Organizer", systemIcon: "trash", destructive: true },
+      ]}
+      onPress={(event) => {
+        if (event.nativeEvent.name === "Remove Organizer") onRemove();
       }}
       previewBackgroundColor="transparent"
     >

--- a/Frontend/app/(app)/leagues/[id]/settings/index.tsx
+++ b/Frontend/app/(app)/leagues/[id]/settings/index.tsx
@@ -73,6 +73,8 @@ function LeagueSettingsContent() {
     leagueTeams,
   } = useLeagueDetailContext();
 
+  const canAccess = isOwner || isOrganizer;
+
   const [isPublic, setIsPublic] = useState(false);
   const leagueTeamsQuery = useTeamsByIds(
     leagueTeams.map((team) => team.teamId),
@@ -147,7 +149,7 @@ function LeagueSettingsContent() {
   const { data: userDirectory = [] } = useQuery({
     queryKey: ["user-directory"],
     queryFn: async () => fetchUserDirectory(api),
-    enabled: Boolean(id && (isOwner || isOrganizer)),
+    enabled: Boolean(id && canAccess),
     staleTime: 5 * 60 * 1000,
   });
 
@@ -178,7 +180,7 @@ function LeagueSettingsContent() {
     ]);
   };
 
-  if (!isOwner && !isOrganizer) {
+  if (!canAccess) {
     return (
       <ContentArea background={{ preset: "red" }}>
         <Empty message="You don't have permission to edit this league" />
@@ -215,7 +217,7 @@ function LeagueSettingsContent() {
                 ? { uri: league.logoUrl }
                 : getSportLogo(league.sport)
             }
-            onPress={() => router.push(`/leagues/${id}/settings/edit`)}
+            onPress={isOwner ? () => router.push(`/leagues/${id}/settings/edit`) : undefined}
             logo
           />
         </Form.Section>
@@ -227,7 +229,7 @@ function LeagueSettingsContent() {
             return (
               <LeagueTeamMenu
                 key={teamMembership.id}
-                canDelete={isOwner && !removeTeamMutation.isPending}
+                canDelete={canAccess && !removeTeamMutation.isPending}
                 onDelete={() =>
                   handleLeagueTeamRemove({
                     teamId: teamMembership.teamId,
@@ -285,72 +287,78 @@ function LeagueSettingsContent() {
               </OrganizerMenu>
             );
           })}
-          <Form.Button
-            button="Invite Organizers"
-            onPress={() =>
-              router.push(`/leagues/${id}/settings/invite-organizers`)
-            }
-          />
-        </Form.Section>
-
-        <Form.Section
-          header="Visibility"
-          footer={
-            isPublic
-              ? "Private leagues are not discoverable, cannot be followed by other users, and only members can see posts."
-              : "Public leagues are discoverable, can be followed by other users, and can make public posts."
-          }
-        >
-          {isPublic ? (
+          {isOwner && (
             <Form.Button
-              button="Switch to a Private League"
-              color={AccentColors.red}
+              button="Invite Organizers"
               onPress={() =>
-                handleLeagueSetPrivate({
-                  league,
-                  onConfirm: (payload) => {
-                    updateLeagueMutation.mutate(payload);
-                    setIsPublic(false);
-                  },
-                })
+                router.push(`/leagues/${id}/settings/invite-organizers`)
               }
-              disabled={updateLeagueMutation.isPending}
-            />
-          ) : (
-            <Form.Button
-              button={isPaying ? "Processing…" : "Switch to a Public League"}
-              color={AccentColors.red}
-              onPress={() =>
-                handleLeagueRequestPurchase({
-                  league,
-                  amountCents: 1500,
-                  formatAmount,
-                  runPayment,
-                  onConfirm: (payload) => {
-                    updateLeagueMutation.mutate(payload);
-                    setIsPublic(true);
-                  },
-                })
-              }
-              disabled={isPaying}
             />
           )}
         </Form.Section>
 
-        <Form.Section>
-          <Form.Button
-            button={
-              deleteLeagueMutation.isPending ? "Deleting..." : "Delete League"
+        {isOwner && (
+          <Form.Section
+            header="Visibility"
+            footer={
+              isPublic
+                ? "Private leagues are not discoverable, cannot be followed by other users, and only members can see posts."
+                : "Public leagues are discoverable, can be followed by other users, and can make public posts."
             }
-            color={AccentColors.red}
-            onPress={() =>
-              handleLeagueDelete({
-                onConfirm: () => deleteLeagueMutation.mutate(),
-              })
-            }
-            disabled={deleteLeagueMutation.isPending}
-          />
-        </Form.Section>
+          >
+            {isPublic ? (
+              <Form.Button
+                button="Switch to a Private League"
+                color={AccentColors.red}
+                onPress={() =>
+                  handleLeagueSetPrivate({
+                    league,
+                    onConfirm: (payload) => {
+                      updateLeagueMutation.mutate(payload);
+                      setIsPublic(false);
+                    },
+                  })
+                }
+                disabled={updateLeagueMutation.isPending}
+              />
+            ) : (
+              <Form.Button
+                button={isPaying ? "Processing…" : "Switch to a Public League"}
+                color={AccentColors.red}
+                onPress={() =>
+                  handleLeagueRequestPurchase({
+                    league,
+                    amountCents: 1500,
+                    formatAmount,
+                    runPayment,
+                    onConfirm: (payload) => {
+                      updateLeagueMutation.mutate(payload);
+                      setIsPublic(true);
+                    },
+                  })
+                }
+                disabled={isPaying}
+              />
+            )}
+          </Form.Section>
+        )}
+
+        {isOwner && (
+          <Form.Section>
+            <Form.Button
+              button={
+                deleteLeagueMutation.isPending ? "Deleting..." : "Delete League"
+              }
+              color={AccentColors.red}
+              onPress={() =>
+                handleLeagueDelete({
+                  onConfirm: () => deleteLeagueMutation.mutate(),
+                })
+              }
+              disabled={deleteLeagueMutation.isPending}
+            />
+          </Form.Section>
+        )}
       </Form>
     </ContentArea>
   );

--- a/Frontend/app/(app)/leagues/[id]/settings/index.tsx
+++ b/Frontend/app/(app)/leagues/[id]/settings/index.tsx
@@ -298,69 +298,99 @@ function LeagueSettingsContent() {
         </Form.Section>
 
         {isOwner && (
-          <Form.Section
-            header="Visibility"
-            footer={
-              isPublic
-                ? "Private leagues are not discoverable, cannot be followed by other users, and only members can see posts."
-                : "Public leagues are discoverable, can be followed by other users, and can make public posts."
-            }
-          >
-            {isPublic ? (
-              <Form.Button
-                button="Switch to a Private League"
-                color={AccentColors.red}
-                onPress={() =>
-                  handleLeagueSetPrivate({
-                    league,
-                    onConfirm: (payload) => {
-                      updateLeagueMutation.mutate(payload);
-                      setIsPublic(false);
-                    },
-                  })
-                }
-                disabled={updateLeagueMutation.isPending}
-              />
-            ) : (
-              <Form.Button
-                button={isPaying ? "Processing…" : "Switch to a Public League"}
-                color={AccentColors.red}
-                onPress={() =>
-                  handleLeagueRequestPurchase({
-                    league,
-                    amountCents: 1500,
-                    formatAmount,
-                    runPayment,
-                    onConfirm: (payload) => {
-                      updateLeagueMutation.mutate(payload);
-                      setIsPublic(true);
-                    },
-                  })
-                }
-                disabled={isPaying}
-              />
-            )}
-          </Form.Section>
-        )}
-
-        {isOwner && (
-          <Form.Section>
-            <Form.Button
-              button={
-                deleteLeagueMutation.isPending ? "Deleting..." : "Delete League"
-              }
-              color={AccentColors.red}
-              onPress={() =>
-                handleLeagueDelete({
-                  onConfirm: () => deleteLeagueMutation.mutate(),
-                })
-              }
-              disabled={deleteLeagueMutation.isPending}
-            />
-          </Form.Section>
+          <OwnerOnlySections
+            league={league}
+            isPublic={isPublic}
+            setIsPublic={setIsPublic}
+            isPaying={isPaying}
+            updateLeagueMutation={updateLeagueMutation}
+            deleteLeagueMutation={deleteLeagueMutation}
+            runPayment={runPayment}
+          />
         )}
       </Form>
     </ContentArea>
+  );
+}
+
+function OwnerOnlySections({
+  league,
+  isPublic,
+  setIsPublic,
+  isPaying,
+  updateLeagueMutation,
+  deleteLeagueMutation,
+  runPayment,
+}: Readonly<{
+  league: { name?: string | null; sport?: string | null; level?: string | null; region?: string | null; location?: string | null; logoUrl?: string | null; privacy?: string | null } | null;
+  isPublic: boolean;
+  setIsPublic: (value: boolean) => void;
+  isPaying: boolean;
+  updateLeagueMutation: ReturnType<typeof useUpdateLeague>;
+  deleteLeagueMutation: ReturnType<typeof useDeleteLeague>;
+  runPayment: (onPaid: () => Promise<void> | void) => void;
+}>) {
+  return (
+    <>
+      <Form.Section
+        header="Visibility"
+        footer={
+          isPublic
+            ? "Private leagues are not discoverable, cannot be followed by other users, and only members can see posts."
+            : "Public leagues are discoverable, can be followed by other users, and can make public posts."
+        }
+      >
+        {isPublic ? (
+          <Form.Button
+            button="Switch to a Private League"
+            color={AccentColors.red}
+            onPress={() =>
+              handleLeagueSetPrivate({
+                league,
+                onConfirm: (payload) => {
+                  updateLeagueMutation.mutate(payload);
+                  setIsPublic(false);
+                },
+              })
+            }
+            disabled={updateLeagueMutation.isPending}
+          />
+        ) : (
+          <Form.Button
+            button={isPaying ? "Processing…" : "Switch to a Public League"}
+            color={AccentColors.red}
+            onPress={() =>
+              handleLeagueRequestPurchase({
+                league,
+                amountCents: 1500,
+                formatAmount,
+                runPayment,
+                onConfirm: (payload) => {
+                  updateLeagueMutation.mutate(payload);
+                  setIsPublic(true);
+                },
+              })
+            }
+            disabled={isPaying}
+          />
+        )}
+      </Form.Section>
+
+      <Form.Section>
+        <Form.Button
+          button={
+            deleteLeagueMutation.isPending ? "Deleting..." : "Delete League"
+          }
+          color={AccentColors.red}
+          onPress={() =>
+            handleLeagueDelete({
+              onConfirm: () => deleteLeagueMutation.mutate(),
+            })
+          }
+          disabled={deleteLeagueMutation.isPending}
+        />
+      </Form.Section>
+    </>
   );
 }
 

--- a/Frontend/app/(app)/leagues/[id]/settings/invite-organizers.tsx
+++ b/Frontend/app/(app)/leagues/[id]/settings/invite-organizers.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { useAuth } from "@clerk/clerk-expo";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@/utils/toast";
+import { ContentArea } from "@/components/ui/content-area";
+import { Empty } from "@/components/ui/empty";
+import { Form } from "@/components/form/form";
+import { AccentColors } from "@/constants/colors";
+import { images } from "@/constants/images";
+import { MenuCardItem } from "@/components/form/menu-card-item";
+import { formatFullName } from "@/components/teams/member-row-utils";
+import { Loading } from "@/components/ui/loading";
+import { useLeagueDetail } from "@/hooks/use-league-detail";
+import { fetchUserDirectory } from "@/hooks/messages/api";
+import {
+  GO_LEAGUE_SERVICE_ROUTES,
+  useAxiosWithClerk,
+} from "@/hooks/use-axios-clerk";
+import { errorToString } from "@/utils/error";
+
+function InviteOrganizerToolbar() {
+  return <Stack.Screen.Title>Invite Organizers</Stack.Screen.Title>;
+}
+
+export default function InviteOrganizersScreen() {
+  const params = useLocalSearchParams<{ id?: string }>();
+  const rawId = params.id;
+  const leagueId = Array.isArray(rawId) ? rawId[0] : (rawId ?? "");
+  const api = useAxiosWithClerk();
+  const queryClient = useQueryClient();
+  const { userId } = useAuth();
+  const { isOwner, isOrganizer, league } = useLeagueDetail(leagueId);
+  const canInvite = isOwner || isOrganizer;
+
+  const { data: organizers = [], isLoading: organizersLoading } = useQuery<
+    { id: string; userId: string }[]
+  >({
+    queryKey: ["league-organizers", leagueId],
+    queryFn: async () => {
+      const resp = await api.get(GO_LEAGUE_SERVICE_ROUTES.ORGANIZERS(leagueId));
+      return resp.data ?? [];
+    },
+    enabled: Boolean(leagueId && canInvite),
+  });
+
+  const { data: pendingInviteeIds = [], isLoading: pendingLoading } = useQuery<
+    string[]
+  >({
+    queryKey: ["league-organizer-pending-ids", leagueId],
+    queryFn: async () => {
+      const resp = await api.get(
+        GO_LEAGUE_SERVICE_ROUTES.ORGANIZER_PENDING_IDS(leagueId),
+      );
+      return resp.data ?? [];
+    },
+    enabled: Boolean(leagueId && canInvite),
+  });
+
+  const { data: userDirectory = [], isLoading: usersLoading } = useQuery({
+    queryKey: ["user-directory"],
+    queryFn: async () => fetchUserDirectory(api),
+    enabled: Boolean(leagueId && canInvite),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const createInviteMutation = useMutation({
+    mutationFn: async (inviteeUserId: string) => {
+      await api.post(GO_LEAGUE_SERVICE_ROUTES.ORGANIZER_INVITES(leagueId), {
+        inviteeUserId,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["league-organizer-pending-ids", leagueId],
+      });
+      toast.success("Invite Sent", {
+        description: "The organizer invitation was sent successfully.",
+      });
+    },
+    onError: (err) => {
+      toast.error("Invite Failed", { description: errorToString(err) });
+    },
+  });
+
+  const availableUsers = useMemo(() => {
+    const organizerIds = new Set(organizers.map((o) => o.userId));
+    const pendingIds = new Set(pendingInviteeIds);
+    const ownerId = league?.ownerUserId;
+
+    return userDirectory
+      .filter((user) => user.id !== userId)
+      .filter((user) => user.id !== ownerId)
+      .filter((user) => !organizerIds.has(user.id))
+      .filter((user) => !pendingIds.has(user.id));
+  }, [organizers, pendingInviteeIds, userDirectory, userId, league?.ownerUserId]);
+
+  const isBusy = organizersLoading || pendingLoading || usersLoading;
+
+  return (
+    <ContentArea
+      background={{ preset: "red", mode: "form" }}
+      toolbar={<InviteOrganizerToolbar />}
+    >
+      <Form accentColor={AccentColors.red}>
+        <Form.Section header="Available Users">
+          {isBusy ? (
+            <Loading />
+          ) : availableUsers.length === 0 ? (
+            <Empty message="No available users to invite" />
+          ) : (
+            availableUsers.map((user) => {
+              const name = formatFullName(user.firstname, user.lastname);
+              return (
+                <MenuCardItem
+                  key={user.id}
+                  title={name}
+                  subtitle={user.email}
+                  image={
+                    user.imageUrl
+                      ? { uri: user.imageUrl }
+                      : images.defaultProfile
+                  }
+                  button={{
+                    label: "Invite",
+                    onPress: () => createInviteMutation.mutate(user.id),
+                    disabled: createInviteMutation.isPending,
+                  }}
+                />
+              );
+            })
+          )}
+        </Form.Section>
+      </Form>
+    </ContentArea>
+  );
+}

--- a/Frontend/app/(app)/leagues/[id]/settings/invite.tsx
+++ b/Frontend/app/(app)/leagues/[id]/settings/invite.tsx
@@ -56,7 +56,7 @@ export default function InviteTeamsScreen() {
       const resp = await fetchTeamResults(api, "", false, league?.sport);
       return resp.items ?? [];
     },
-    enabled: Boolean(leagueId && isOwner && league?.sport),
+    enabled: Boolean(leagueId && league?.sport),
   });
 
   const pendingInvitesQuery = useQuery<LeagueInviteResponse[]>({

--- a/Frontend/hooks/use-axios-clerk.ts
+++ b/Frontend/hooks/use-axios-clerk.ts
@@ -162,6 +162,14 @@ export const GO_LEAGUE_SERVICE_ROUTES = {
     buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/posts`),
   LEAGUE_POST: (leagueId: string, postId: string) =>
     buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/posts/${postId}`),
+  ORGANIZERS: (leagueId: string) =>
+  buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizers`),
+  REMOVE_ORGANIZER: (leagueId: string, organizerUserId: string) =>
+    buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizers/${organizerUserId}`),
+  ORGANIZER_INVITES: (leagueId: string) =>
+    buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizer-invites`),
+  ORGANIZER_PENDING_IDS: (leagueId: string) =>
+    buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizer-invites/pending-ids`),
 };
 
 const leagueInvitesBase = buildRoute(VERSIONING.v1, "league-invites");

--- a/Frontend/hooks/use-axios-clerk.ts
+++ b/Frontend/hooks/use-axios-clerk.ts
@@ -163,7 +163,7 @@ export const GO_LEAGUE_SERVICE_ROUTES = {
   LEAGUE_POST: (leagueId: string, postId: string) =>
     buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/posts/${postId}`),
   ORGANIZERS: (leagueId: string) =>
-  buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizers`),
+    buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizers`),
   REMOVE_ORGANIZER: (leagueId: string, organizerUserId: string) =>
     buildRoute(VERSIONING.v1, SERVICE.LEAGUES, `${leagueId}/organizers/${organizerUserId}`),
   ORGANIZER_INVITES: (leagueId: string) =>
@@ -179,6 +179,14 @@ export const GO_LEAGUE_INVITE_ROUTES = {
     buildRoute(VERSIONING.v1, "teams", `${teamId}/league-invites`),
   ACCEPT: (inviteId: string) => `${leagueInvitesBase}/${inviteId}/accept`,
   DECLINE: (inviteId: string) => `${leagueInvitesBase}/${inviteId}/decline`,
+};
+
+const leagueOrganizerInvitesBase = buildRoute(VERSIONING.v1, "league-organizer-invites");
+
+export const GO_LEAGUE_ORGANIZER_INVITE_ROUTES = {
+  MINE: `${leagueOrganizerInvitesBase}/mine`,
+  ACCEPT: (inviteId: string) => `${leagueOrganizerInvitesBase}/${inviteId}/accept`,
+  DECLINE: (inviteId: string) => `${leagueOrganizerInvitesBase}/${inviteId}/decline`,
 };
 
 const messagingBase = buildRoute(VERSIONING.v1, SERVICE.MESSAGING);

--- a/Frontend/hooks/use-league-detail.ts
+++ b/Frontend/hooks/use-league-detail.ts
@@ -7,6 +7,7 @@ import {
 } from "@/hooks/use-axios-clerk";
 import { createScopedLog } from "@/utils/logger";
 
+
 const log = createScopedLog("League Detail");
 
 export function useLeagueDetail(id: string) {
@@ -73,6 +74,21 @@ export function useLeagueDetail(id: string) {
     refetchOnWindowFocus: false,
   });
 
+  const { data: organizersData = [] } = useQuery<{ userId: string }[]>({
+    queryKey: ["league-organizers", id],
+    queryFn: async () => {
+      try {
+        const resp = await api.get(GO_LEAGUE_SERVICE_ROUTES.ORGANIZERS(id));
+        return resp.data ?? [];
+      } catch {
+        return [];
+      }
+    },
+    enabled: Boolean(id) && Boolean(userId),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
   const leagueTeams = Array.isArray(leagueTeamsData) ? leagueTeamsData : [];
 
   const onRefresh = useCallback(async () => {
@@ -91,6 +107,9 @@ export function useLeagueDetail(id: string) {
 
   const title = league?.name ?? (id ? `League ${id}` : "League");
   const isOwner = Boolean(userId && league?.ownerUserId === userId);
+  const isOrganizer = Boolean(
+    userId && organizersData.some((o) => o.userId === userId),
+  );
   const isMember = myLeagueTeams.length > 0;
 
   return {
@@ -107,5 +126,6 @@ export function useLeagueDetail(id: string) {
     isLeagueTeamsLoading,
     leagueTeamsError,
     refetchLeagueTeams,
+    isOrganizer,
   };
 }

--- a/Frontend/hooks/use-notifications.ts
+++ b/Frontend/hooks/use-notifications.ts
@@ -17,6 +17,7 @@ import {
 import {
   GO_INVITE_ROUTES,
   GO_LEAGUE_INVITE_ROUTES,
+  GO_LEAGUE_ORGANIZER_INVITE_ROUTES,
   GO_MATCH_ROUTES,
   useAxiosWithClerk,
 } from "@/hooks/use-axios-clerk";
@@ -178,6 +179,23 @@ export function useNotifications() {
     onError: handleInviteResponseError,
   });
 
+  const respondToOrganizerInvite = useMutation({
+    mutationFn: async (payload: InvitationResponsePayload) => {
+      const endpoint = payload.isAccepted
+        ? GO_LEAGUE_ORGANIZER_INVITE_ROUTES.ACCEPT(payload.invitationId)
+        : GO_LEAGUE_ORGANIZER_INVITE_ROUTES.DECLINE(payload.invitationId);
+      await api.post(endpoint);
+    },
+    onSuccess: async (_data, variables) => {
+      await handleInvitationSuccess(variables, {
+        acceptedMessage: "You are now a league organizer.",
+        declinedMessage: notificationCopy.invitationDeclinedMessage,
+        invalidateKeys: [["league-organizers"]],
+      });
+    },
+    onError: handleInviteResponseError,
+  });
+
   const respondToTeamMatchInvite = useMutation({
     mutationFn: async (payload: MatchInvitationResponsePayload) => {
       const endpoint = payload.isAccepted
@@ -235,6 +253,14 @@ export function useNotifications() {
         return;
       }
 
+      if (notification.kind === "league-organizer") {
+        respondToOrganizerInvite.mutate({
+          invitationId: notification.id,
+          isAccepted,
+        });
+        return;
+      }
+
       if (notification.kind === "team-match") {
         respondToTeamMatchInvite.mutate({
           matchId: notification.matchId,
@@ -250,6 +276,7 @@ export function useNotifications() {
     },
     [
       respondToLeagueInvite,
+      respondToOrganizerInvite,
       respondToRefereeInvite,
       respondToTeamInvite,
       respondToTeamMatchInvite,

--- a/Frontend/types/leagues.ts
+++ b/Frontend/types/leagues.ts
@@ -22,3 +22,12 @@ export type LeagueInviteCard = {
   sport?: string | null;
 };
 
+export type LeagueOrganizerInviteCard = {
+  kind: "league-organizer";
+  id: string;
+  leagueId: string;
+  leagueName: string;
+  inviterName?: string;
+  logoUrl?: string | null;
+  sport?: string | null;
+};

--- a/Frontend/types/notifications.ts
+++ b/Frontend/types/notifications.ts
@@ -1,4 +1,4 @@
-import { LeagueInviteCard } from "@/types/leagues";
+import { LeagueInviteCard, LeagueOrganizerInviteCard } from "@/types/leagues";
 import { RefereeMatchInviteCard, TeamMatchInviteCard } from "@/types/matches";
 
 export type TeamInviteResponse = {
@@ -27,6 +27,7 @@ export type TeamInviteCard = {
 export type NotificationItem =
   | TeamInviteCard
   | LeagueInviteCard
+  | LeagueOrganizerInviteCard
   | TeamMatchInviteCard
   | RefereeMatchInviteCard;
 

--- a/Frontend/utils/leagues.ts
+++ b/Frontend/utils/leagues.ts
@@ -4,6 +4,7 @@ import { Alert } from "react-native";
 import { fetchTeamResults } from "@/utils/search";
 import {
   GO_LEAGUE_INVITE_ROUTES,
+  GO_LEAGUE_ORGANIZER_INVITE_ROUTES,
   GO_LEAGUE_SERVICE_ROUTES,
 } from "@/hooks/use-axios-clerk";
 import { isRunningInExpoGo } from "@/utils/runtime";
@@ -11,8 +12,10 @@ import { LeagueTeamMembership } from "@/types/matches";
 import {
   LeagueInviteCard,
   LeagueInviteResponse,
+  LeagueOrganizerInviteCard,
   LeaguePrivacy,
 } from "@/types/leagues";
+import { fetchUserNameMap } from "@/utils/notifications";
 
 type ShowActionSheet = ReturnType<
   typeof useActionSheet
@@ -271,6 +274,39 @@ export async function fetchLeagueInvitesWithDetails(
     teamId: invite.teamId,
     teamName: invite.teamName ?? "Team",
     leaguePrivacy: leagueMap[invite.leagueId]?.privacy ?? LeaguePrivacy.PRIVATE,
+    logoUrl: leagueMap[invite.leagueId]?.logoUrl,
+    sport: leagueMap[invite.leagueId]?.sport,
+  }));
+}
+
+export async function fetchOrganizerInvitesWithDetails(
+  api: AxiosInstance,
+): Promise<LeagueOrganizerInviteCard[]> {
+  const resp = await api.get<
+    { id: string; leagueId: string; invitedByUserId?: string; status?: string }[]
+  >(GO_LEAGUE_ORGANIZER_INVITE_ROUTES.MINE);
+
+  const invites = (resp.data ?? []).filter((i) => i.status === "PENDING");
+  if (invites.length === 0) return [];
+
+  const leagueIds = Array.from(new Set(invites.map((i) => i.leagueId)));
+  const inviterIds = Array.from(
+    new Set(invites.map((i) => i.invitedByUserId).filter(Boolean)),
+  ) as string[];
+
+  const [leagueMap, inviterMap] = await Promise.all([
+    fetchLeagueMetaMap(api, leagueIds),
+    fetchUserNameMap(api, inviterIds),
+  ]);
+
+  return invites.map((invite) => ({
+    kind: "league-organizer" as const,
+    id: invite.id,
+    leagueId: invite.leagueId,
+    leagueName: leagueMap[invite.leagueId]?.name ?? "League",
+    inviterName: invite.invitedByUserId
+      ? (inviterMap[invite.invitedByUserId] ?? undefined)
+      : undefined,
     logoUrl: leagueMap[invite.leagueId]?.logoUrl,
     sport: leagueMap[invite.leagueId]?.sport,
   }));

--- a/Frontend/utils/notifications.ts
+++ b/Frontend/utils/notifications.ts
@@ -19,7 +19,10 @@ import {
   TeamInviteCard,
   TeamInviteResponse,
 } from "@/types/notifications";
-import { fetchLeagueInvitesWithDetails } from "@/utils/leagues";
+import {
+  fetchLeagueInvitesWithDetails,
+  fetchOrganizerInvitesWithDetails,
+} from "@/utils/leagues";
 
 export function getNotificationsQueryKey(userId?: string | null) {
   return [userNotificationsQueryKey, userId] as const;
@@ -29,10 +32,11 @@ export async function fetchNotificationsWithDetails(
   api: AxiosInstance,
   userId: string,
 ): Promise<NotificationItem[]> {
-  const [teamInvites, leagueInvites, teamMatchInvites, refereeInvites] =
+  const [teamInvites, leagueInvites, organizerInvites, teamMatchInvites, refereeInvites] =
     await Promise.all([
       fetchTeamInvitesWithDetails(api).catch(() => []),
       fetchLeagueInvitesWithDetails(api).catch(() => []),
+      fetchOrganizerInvitesWithDetails(api).catch(() => []),
       (userId
         ? fetchIncomingTeamMatchInvites(api, userId)
         : Promise.resolve([])
@@ -43,6 +47,7 @@ export async function fetchNotificationsWithDetails(
   return [
     ...teamInvites,
     ...leagueInvites,
+    ...organizerInvites,
     ...teamMatchInvites,
     ...refereeInvites,
   ];
@@ -125,6 +130,17 @@ export function getInviteContent(
     };
   }
 
+  if (notification.kind === "league-organizer") {
+    return {
+      spaceName: notification.leagueName,
+      logoUrl: notification.logoUrl,
+      sport: notification.sport,
+      body: `You've been invited${
+        notification.inviterName ? ` by ${notification.inviterName}` : ""
+      } to be an organizer of ${notification.leagueName}.`,
+    };
+  }
+
   return {
     spaceName: notification.leagueName,
     logoUrl: notification.logoUrl,
@@ -198,7 +214,7 @@ async function fetchTeamMetaMap(
   return Object.fromEntries(entries);
 }
 
-async function fetchUserNameMap(api: AxiosInstance, userIds: string[]) {
+export async function fetchUserNameMap(api: AxiosInstance, userIds: string[]) {
   const entries = await Promise.all(
     userIds.map(async (userId) => {
       try {

--- a/feature-flags/UserService.json
+++ b/feature-flags/UserService.json
@@ -1,0 +1,4 @@
+[ {
+  "key" : "USER_SERVICE_BASE",
+  "enabled" : false
+} ]


### PR DESCRIPTION
## Summary
 
Adds the ability for league owners to invite users as league organizers, admin users who can help manage the league without being the owner.
 
## What changed
 
### Backend

***Overall Design Idea***:
<img width="2018" height="1144" alt="image" src="https://github.com/user-attachments/assets/88865b82-78a2-490d-a348-be17566658a6" />

**New tables** (`V12` migration):
- `league_organizers` — join table linking users to leagues as organizers
- `league_organizer_invites` — tracks pending/accepted/declined organizer invitations
 
**New files:**
- `LeagueOrganizer` entity, `LeagueOrganizerInvite` entity, `LeagueOrganizerInviteStatus` enum
- `LeagueOrganizerRepository`, `LeagueOrganizerInviteRepository`
- `LeagueOrganizerInviteCreateRequest`, `LeagueOrganizerResponse`, `LeagueOrganizerInviteResponse` DTOs
- `LeagueOrganizerService` — create/accept/decline invites, list organizers, remove organizer
- `LeagueOrganizerController` — REST endpoints for all organizer operations
 
**Modified files:**
- `LeagueService` — `ensureOwner` and `ensureCanView` now also check the `league_organizers` table; `listLeagues` with `my=true` now includes leagues where the user is an organizer
- `LeagueInviteService` — `ensureLeagueOwner` widened to allow organizers
- `LeagueMatchService` — `ensureLeagueOwner` widened to allow organizers
- `LeaguePostService` — `ensureOwner` and `canViewMembersScope` widened to allow organizers
- `LeagueOrganizerRepository` — added `findByUserId` for the spaces listing query
 
**API gateway:**
- Added `/api/v1/league-organizer-invites/**` route to `go-api-gateway.yml` so organizer invite endpoints reach the league service
 
### Frontend
 
**New files:**
- `leagues/[id]/settings/invite-organizers.tsx` — screen to invite users as organizers (mirrors the team invite screen)
 
**Modified files:**
- `hooks/use-axios-clerk.ts` — added `ORGANIZERS`, `REMOVE_ORGANIZER`, `ORGANIZER_INVITES`, `ORGANIZER_PENDING_IDS` routes to `GO_LEAGUE_SERVICE_ROUTES`; added `GO_LEAGUE_ORGANIZER_INVITE_ROUTES` for accept/decline/mine
- `hooks/use-league-detail.ts` — added `isOrganizer` flag derived from organizers query
- `hooks/use-notifications.ts` — added `respondToOrganizerInvite` mutation and `"league-organizer"` case in the `respond` callback
- `types/leagues.ts` — added `LeagueOrganizerInviteCard` type
- `types/notifications.ts` — added `LeagueOrganizerInviteCard` to `NotificationItem` union
- `utils/leagues.ts` — added `fetchOrganizerInvitesWithDetails` function
- `utils/notifications.ts` — wired organizer invites into `fetchNotificationsWithDetails`; added `"league-organizer"` case to `getInviteContent`; exported `fetchUserNameMap`
- `leagues/[id]/index.tsx` — organizers now see the settings gear icon instead of "Follow"; organizers can create posts, schedule matches, and delete posts
- `leagues/[id]/settings/index.tsx` — organizers section with owner-only remove (long-press context menu); organizers can manage teams but cannot edit league profile, change visibility, invite/remove organizers, or delete the league
 
## Organizer permissions
 
| Action | Owner | Organizer |
|--------|-------|-----------|
| Edit league profile (name, logo, sport) | ✅ | ❌ |
| Manage teams (invite, remove) | ✅ | ✅ |
| View & manage matches | ✅ | ✅ |
| Create & delete posts | ✅ | ✅ |
| View organizers list | ✅ | ✅ |
| Invite organizers | ✅ | ❌ |
| Remove organizers | ✅ | ❌ |
| Change league visibility | ✅ | ❌ |
| Delete league | ✅ | ❌ |
| League appears in spaces | ✅ | ✅ |
| Settings gear icon visible | ✅ | ✅ |
 
## API endpoints
 
| Method | Path | Access |
|--------|------|--------|
| `GET` | `/leagues/{id}/organizers` | Anyone who can view the league |
| `DELETE` | `/leagues/{id}/organizers/{userId}` | Owner only |
| `POST` | `/leagues/{id}/organizer-invites` | Owner or organizer |
| `GET` | `/leagues/{id}/organizer-invites/pending-ids` | Owner or organizer |
| `GET` | `/league-organizer-invites/mine` | Authenticated user (own invites) |
| `POST` | `/league-organizer-invites/{id}/accept` | The invitee |
| `POST` | `/league-organizer-invites/{id}/decline` | The invitee |
 
## How to test
 
1. As league owner, go to league settings → Organizers → Invite Organizers → invite a user
2. As the invited user, open notifications → accept the organizer invite
3. Verify the league appears in the organizer's spaces
4. As organizer, verify: settings gear visible, can manage teams, can post/schedule, cannot edit profile or change visibility/delete
5. As owner, long-press an organizer in settings → Remove Organizer

## Video

https://github.com/user-attachments/assets/08ff5acc-9ddd-446e-aa4f-4f6bc624f14a

