### PR TITLE
[hotfix] Allow empty component to render for feed error & capitalize toast title

### DIFF
--- a/Frontend/__tests__/feed/home-feed-list.test.tsx
+++ b/Frontend/__tests__/feed/home-feed-list.test.tsx
@@ -141,12 +141,12 @@ describe("HomeFeedList", () => {
   });
 
   it("renders error state", () => {
-    const { queryByText, queryByTestId } = render(
+    const { getByTestId, getByText, queryByTestId } = render(
       <HomeFeedList items={[]} isLoading={false} errorText="boom" />,
     );
 
-    expect(queryByText("Failed to load feed")).toBeNull();
-    expect(queryByTestId("empty")).toBeNull();
+    expect(getByTestId("empty")).toBeTruthy();
+    expect(getByText("Failed to load feed")).toBeTruthy();
     expect(queryByTestId("loading")).toBeNull();
   });
 

--- a/Frontend/__tests__/feed/home-feed-list.test.tsx
+++ b/Frontend/__tests__/feed/home-feed-list.test.tsx
@@ -134,25 +134,15 @@ describe("HomeFeedList", () => {
 
   it("renders loading state", () => {
     const { getByTestId } = render(
-      <HomeFeedList items={[]} isLoading={true} errorText={null} />,
+      <HomeFeedList items={[]} isLoading={true} />,
     );
 
     expect(getByTestId("loading")).toBeTruthy();
   });
 
-  it("renders error state", () => {
-    const { getByTestId, getByText, queryByTestId } = render(
-      <HomeFeedList items={[]} isLoading={false} errorText="boom" />,
-    );
-
-    expect(getByTestId("empty")).toBeTruthy();
-    expect(getByText("Failed to load feed")).toBeTruthy();
-    expect(queryByTestId("loading")).toBeNull();
-  });
-
   it("renders empty state", () => {
     const { getByTestId, getByText } = render(
-      <HomeFeedList items={[]} isLoading={false} errorText={null} />,
+      <HomeFeedList items={[]} isLoading={false} />,
     );
 
     expect(getByTestId("empty")).toBeTruthy();
@@ -165,7 +155,6 @@ describe("HomeFeedList", () => {
       <HomeFeedList
         items={[postItem, matchItem]}
         isLoading={false}
-        errorText={null}
         onMatchPress={onMatchPress}
       />,
     );
@@ -182,7 +171,7 @@ describe("HomeFeedList", () => {
 
   it("passes undefined onPress when onMatchPress is omitted", () => {
     render(
-      <HomeFeedList items={[matchItem]} isLoading={false} errorText={null} />,
+      <HomeFeedList items={[matchItem]} isLoading={false} />,
     );
 
     expect(mockMatchCard).toHaveBeenCalledWith(
@@ -199,7 +188,6 @@ describe("HomeFeedList", () => {
       <HomeFeedList
         items={[postItem]}
         isLoading={false}
-        errorText={null}
         onPostPress={onPostPress}
       />,
     );

--- a/Frontend/__tests__/hooks/use-home-feed.test.ts
+++ b/Frontend/__tests__/hooks/use-home-feed.test.ts
@@ -645,7 +645,7 @@ describe("useHomeFeed", () => {
     };
 
     await expect(options.queryFn()).rejects.toThrow("boom");
-    expect(mockedToastError).toHaveBeenCalledWith("Failed to load feed", {
+    expect(mockedToastError).toHaveBeenCalledWith("Failed to Load Feed", {
       description: "boom",
     });
   });

--- a/Frontend/app/(app)/(tabs)/(home)/index.tsx
+++ b/Frontend/app/(app)/(tabs)/(home)/index.tsx
@@ -11,7 +11,6 @@ import { useNotificationsCount } from "@/hooks/use-notifications";
 import { useQueryClient } from "@tanstack/react-query";
 import { HomeFeedList } from "@/components/feed/home-feed-list";
 import { useHomeFeed } from "@/hooks/use-home-feed";
-import { errorToString } from "@/utils/error";
 import type { HomeFeedMatchItem, HomeFeedPostItem } from "@/types/feed";
 
 function HomeToolbar() {
@@ -62,7 +61,6 @@ export default function Home() {
   const { userId } = useAuth();
   const {
     data: feedItems = [],
-    error: feedError,
     isLoading: feedLoading,
     isRefetching: feedRefetching,
     refetch: refetchFeed,
@@ -131,7 +129,6 @@ export default function Home() {
         <HomeFeedList
           items={feedItems}
           isLoading={feedLoading}
-          errorText={feedError ? errorToString(feedError) : null}
           onMatchPress={handleMatchPress}
           onPostPress={handlePostPress}
         />

--- a/Frontend/components/feed/home-feed-list.tsx
+++ b/Frontend/components/feed/home-feed-list.tsx
@@ -15,7 +15,6 @@ import { getSportLogo } from "@/utils/search";
 interface HomeFeedListProps {
   readonly items: HomeFeedItem[];
   readonly isLoading: boolean;
-  readonly errorText?: string | null;
   readonly onMatchPress?: (item: HomeFeedMatchItem) => void;
   readonly onPostPress?: (item: HomeFeedPostItem) => void;
 }
@@ -23,7 +22,6 @@ interface HomeFeedListProps {
 export function HomeFeedList({
   items,
   isLoading,
-  errorText,
   onMatchPress,
   onPostPress,
 }: Readonly<HomeFeedListProps>) {
@@ -79,10 +77,6 @@ export function HomeFeedList({
 
   if (isLoading) {
     return <Loading />;
-  }
-
-  if (errorText) {
-    return <Empty message="Failed to load feed" />;
   }
 
   if (items.length === 0) {

--- a/Frontend/components/feed/home-feed-list.tsx
+++ b/Frontend/components/feed/home-feed-list.tsx
@@ -82,7 +82,7 @@ export function HomeFeedList({
   }
 
   if (errorText) {
-    return null;
+    return <Empty message="Failed to load feed" />;;
   }
 
   if (items.length === 0) {

--- a/Frontend/components/feed/home-feed-list.tsx
+++ b/Frontend/components/feed/home-feed-list.tsx
@@ -82,7 +82,7 @@ export function HomeFeedList({
   }
 
   if (errorText) {
-    return <Empty message="Failed to load feed" />;;
+    return <Empty message="Failed to load feed" />;
   }
 
   if (items.length === 0) {

--- a/Frontend/hooks/use-home-feed.ts
+++ b/Frontend/hooks/use-home-feed.ts
@@ -419,7 +419,7 @@ export function useHomeFeed() {
         return feed;
       } catch (error) {
         log.error("Failed to fetch home feed", { userId, error });
-        toast.error("Failed to load feed", {
+        toast.error("Failed to Load Feed", {
           description: errorToString(error),
         });
         throw error;


### PR DESCRIPTION
## Description

Correct small UI issues.

- Allow empty component to render when there is an error loading the home feed
- Capitalize toast title when there is an error loading the home feed